### PR TITLE
Update Frontegg AdminPortal to 3.10.0

### DIFF
--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "^3.3.0",
-    "@frontegg/redux-store": "^3.3.0",
+    "@frontegg/admin-portal": "3.5.4",
+    "@frontegg/redux-store": "3.5.4",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.7.1",
-    "@frontegg/redux-store": "3.7.1",
+    "@frontegg/admin-portal": "3.7.2",
+    "@frontegg/redux-store": "3.7.2",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.5.4",
-    "@frontegg/redux-store": "3.5.4",
+    "@frontegg/admin-portal": "3.5.6",
+    "@frontegg/redux-store": "3.5.6",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.7.0",
-    "@frontegg/redux-store": "3.7.0",
+    "@frontegg/admin-portal": "3.7.1",
+    "@frontegg/redux-store": "3.7.1",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.9.1",
-    "@frontegg/redux-store": "3.9.1",
+    "@frontegg/admin-portal": "3.10.0",
+    "@frontegg/redux-store": "3.10.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.6.0",
-    "@frontegg/redux-store": "3.6.0",
+    "@frontegg/admin-portal": "3.7.0",
+    "@frontegg/redux-store": "3.7.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.5.6",
-    "@frontegg/redux-store": "3.5.6",
+    "@frontegg/admin-portal": "3.6.0",
+    "@frontegg/redux-store": "3.6.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.9.0",
-    "@frontegg/redux-store": "3.9.0",
+    "@frontegg/admin-portal": "3.9.1",
+    "@frontegg/redux-store": "3.9.1",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.7.2",
-    "@frontegg/redux-store": "3.7.2",
+    "@frontegg/admin-portal": "3.9.0",
+    "@frontegg/redux-store": "3.9.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }


### PR DESCRIPTION
### AdminPortal 3.10.0:
- v3.10.0
- FR-3140 - Fix 'replace' module if exists
- FR-3140 - Remove package json module key for Frontegg libraries
- FR-2475 - add custom login footer

## AdminPortal v3.9.1
- hide subscription tab