### PR TITLE
Update Frontegg AdminPortal to 3.13.0

### DIFF
--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.12.0",
-    "@frontegg/redux-store": "3.12.0",
+    "@frontegg/admin-portal": "3.13.0",
+    "@frontegg/redux-store": "3.13.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }


### PR DESCRIPTION
### AdminPortal 3.13.0:
- v3.13.0
- Fix admin box loading
- FR-3651 Connectivity is sending ~300 fetch requests for slack configuration
- FR-3846 - custom input error
- FR-3863 - cannot add public key manually
- FR-3548 - add externally managed screen, refactor code