### PR TITLE
Update Frontegg AdminPortal to 3.15.0

### DIFF
--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.13.0",
-    "@frontegg/redux-store": "3.13.0",
+    "@frontegg/admin-portal": "3.14.0",
+    "@frontegg/redux-store": "3.14.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.0",
-    "@frontegg/redux-store": "3.14.0",
+    "@frontegg/admin-portal": "3.14.1",
+    "@frontegg/redux-store": "3.14.1",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,8 +7,8 @@
     "@angular/core": "^12.0.5"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.1",
-    "@frontegg/redux-store": "3.14.1",
+    "@frontegg/admin-portal": "3.15.0",
+    "@frontegg/redux-store": "3.15.0",
     "fast-deep-equal": "^3.1.3",
     "tslib": "^2.0.0"
   }


### PR DESCRIPTION
### AdminPortal 3.15.0:
- v3.15.0
- FR-3814 - fix configuration
- FR-3944 - remove logs and added custom loader to a condition in injector
- FR-3987 - fix social layout

### AdminPortal 3.14.1:
- v3.14.1
- FR-3944 - Added custom loader as an option to refetch request authorize
- FR-3981 - when choose other  saml vendor then reset saml config to manual
- id for admin box x
- FR-3889 - support permissions in admin box
- FR-3793 - add login box customizion
- FR-3596 - custom social login icon

### AdminPortal 3.14.0:
- v3.14.0
- FR-3944 - added logs tp debug in prod
- FR-3795 - custom text to signUp switch