### PR TITLE
Update Frontegg AdminPortal to 6.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.2.1",
+    "@frontegg/js": "6.2.2",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.2.1",
+    "@frontegg/js": "6.2.2",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,18 +1131,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.2.0.tgz#0c2581af2b2b56f5c975b549fce240d6094d79a8"
-  integrity sha512-gw8AWwi1xxUzCwEpTL4TAZJZol15jJORtaxiWeSjG8HBoGe3K0ef/Ub9tOQlUbdRkzZWXOw6M4n5lCA1gjZivA==
+"@frontegg/js@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.2.1.tgz#256d96855324de200c289c90ef0027b1977e3802"
+  integrity sha512-UnMiXm6aYpu/6uYktrOJUUCbZXHZgh/AgYMw42bNH6D0iDD9QNBCsA9p2zuZ87MCjj1wjccCs4vIJoPdGE4PyQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/types" "6.2.0"
+    "@frontegg/types" "6.2.1"
 
-"@frontegg/redux-store@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.0.tgz#d030ec32ada7bb331926bc2c4b382cf9a35450d2"
-  integrity sha512-mHiHnfVcdxvsYXqu1gkjMka2jsBPWw9jX3tonba+znU82N29P+JDHB8necOEiaVSBjilAEPwQZ9VTFkiQpqVRg==
+"@frontegg/redux-store@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.1.tgz#e8843c680c19dc1fea79fa0d326f18190c500178"
+  integrity sha512-td5rArnr3fcc9v6DT9xnrEs4HEMKsjY5qAScSGgQlawACCr+TM21LgQbIQzMJFg4k3WW0tJAfJDVHVb1T5p3bA==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/rest-api" "3.0.11"
@@ -1157,13 +1157,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.0.tgz#a2d3c18a967cd438058852bf77238893d42316c2"
-  integrity sha512-R+i61fhUc9Kk1FmQ4oVSnTg2XqcSWZHnQ1cJk8qfdNOasHP/F9xGd00Z5iAgdL05trM2DHMtFAJEa51gMtZHYQ==
+"@frontegg/types@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.1.tgz#3ee5b9f13632f413b85ec88843a067e4c5a6f611"
+  integrity sha512-mNoJPISnlEKF/P/muQESPAXEBNnTqciLeFEoTkkuRwAzuW7jDOnjom+sVIM2sPohtW0qjnP4D0NKzVB9zo+kBw==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.2.0"
+    "@frontegg/redux-store" "6.2.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.2.2:
- [FR-8221](https://frontegg.atlassian.net/browse/FR-8221) - Fix bugs in dashboard builder mode - [b2af8970](https://github.com/frontegg/admin-box/pulls?q=b2af8970)