### PR TITLE
Update Frontegg AdminPortal to 6.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.2.2",
+    "@frontegg/js": "6.2.3",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.2.2",
+    "@frontegg/js": "6.2.3",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",


### PR DESCRIPTION
### AdminPortal 6.2.3:
- [FR-8413](https://frontegg.atlassian.net/browse/FR-8413) - fix adminBox tab permissions - [5d98601a](https://github.com/frontegg/admin-box/pulls?q=5d98601a)