### PR TITLE
Update Frontegg AdminPortal to 6.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.3.0",
+    "@frontegg/js": "6.4.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.2.5",
+    "@frontegg/js": "6.3.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.2.5",
+    "@frontegg/js": "6.3.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.3.0",
+    "@frontegg/js": "6.4.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,18 +1131,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.2.5":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.2.5.tgz#67e6bf473e6748b6d77d81fcf3ad2f261b4e418d"
-  integrity sha512-9eqpI3docIVtkzaLFS+etl6pNk8Vg0MdNYIGOQDdZ970G98P/3lEE4hxFbmeNCAoaUS2Bs/H56nXzPklqIE0yw==
+"@frontegg/js@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.3.0.tgz#fc94ffa5df3940d24c86b55612b93f0f75f246d5"
+  integrity sha512-HvGyv8uunmipeEwwEMP3c1OS9Hm+WyjrCgANVEsbadlLTaBVofKivonJlg6CSDYdgiZnmpJs4ZzctnMLt8OCvg==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/types" "6.2.5"
+    "@frontegg/types" "6.3.0"
 
-"@frontegg/redux-store@6.2.5":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.5.tgz#e772073beacc814502a2a9106f2c322a45aa743c"
-  integrity sha512-mIeaDUHhzihTsyz4MOZsslsiM4EXFfwweBtjmQ30U2Io8SO/yJE0/Opc6JNvmh/s/LesvPWayBWJ2lRgatcPMw==
+"@frontegg/redux-store@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.3.0.tgz#31df418e647654160c44e9584729fe72286c370f"
+  integrity sha512-wiScdbkHs1GJsdUX1jKRjiRagDIndp98jlomwMG5YDufhVYYxjNJmYPtqJ9K1yyDct30ihSsoDNWTQ/62Z+qIw==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/rest-api" "3.0.11"
@@ -1157,13 +1157,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.2.5":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.5.tgz#934c5b2aeb68ab1b6563e17bc7c5a28127df88d5"
-  integrity sha512-yJn1Nn2c6s63zaeMDqyiNkM5Q0yWNylplFXR6l8iuCzHnbilAuL5BtHJ6rBNbHdwECsffB+Dwp+OX5UhPzXAGA==
+"@frontegg/types@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.3.0.tgz#b4f32e46892cf9dbfad90d9964b4bed84999996b"
+  integrity sha512-VDkqeTNlXjD4qNAtQ207tvMyU/aOo5l9Bz5kPi7LpTSnksT3B7Ele6qLG+qNsMgHq1aYUzp788yOT6I4ZSCz0Q==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.2.5"
+    "@frontegg/redux-store" "6.3.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.4.0:
- [FR-8221](https://frontegg.atlassian.net/browse/FR-8221) -  Remove @razshlomo17 from CODEOWNERS - [571bf85b](https://github.com/frontegg/admin-box/pulls?q=571bf85b)
- [FR-8921](https://frontegg.atlassian.net/browse/FR-8921) - test plan for login box - [cc128ca1](https://github.com/frontegg/admin-box/pulls?q=cc128ca1)
- [FR-7615](https://frontegg.atlassian.net/browse/FR-7615) - Fix Permissions for viewing API tokens - [d5cc58dd](https://github.com/frontegg/admin-box/pulls?q=d5cc58dd)

### AdminPortal 6.3.0:
- [FR-8221](https://frontegg.atlassian.net/browse/FR-8221) - fix renderer issue in dashboard builder - [cef2fe7b](https://github.com/frontegg/admin-box/pulls?q=cef2fe7b)