### PR TITLE
Update Frontegg AdminPortal to 6.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.5.1",
+    "@frontegg/js": "6.6.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.6.1",
+    "@frontegg/js": "6.7.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.6.0",
+    "@frontegg/js": "6.6.1",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.8.0",
+    "@frontegg/js": "6.8.1",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.7.0",
+    "@frontegg/js": "6.8.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.6.0",
+    "@frontegg/js": "6.6.1",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.8.0",
+    "@frontegg/js": "6.8.1",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.6.1",
+    "@frontegg/js": "6.7.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.5.1",
+    "@frontegg/js": "6.6.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.7.0",
+    "@frontegg/js": "6.8.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.5.1":
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.5.1.tgz#8f8b7b2eb582f317338591096b9c03519887cc93"
-  integrity sha512-CugtQhVGyLgcgTX/8hJEXH1KsO/ZzanhxUR+PrflmAxqWkh2KFRMRDx7FFPJz3vLIL4VdwwX5oVhGbK4usXU4g==
+"@frontegg/js@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.6.0.tgz#f2517fda524a3c56df742fe48f5b52f68e4e353d"
+  integrity sha512-RsnonFO+sx2F6ANRTKf/SP7WOKaHd1tlBjRqpC1fa/Pvzuvv73+vAUNtpbY6lihJVNQVpt+R4keadDXXEa9P0w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.5.1"
+    "@frontegg/types" "6.6.0"
 
-"@frontegg/redux-store@6.5.1":
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.5.1.tgz#9cb4813eb1d8cb0ba02257adae8ca70aa2d0eebb"
-  integrity sha512-iIRXTomE5+wNyVXyadZoFPyY4Izc1JQNouHhGoDh762S9TSD2gfzGQa5dixEZbJALurh1/RBZIJjGAFItuQO8A==
+"@frontegg/redux-store@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.6.0.tgz#24309ea1c4de4abe7691b02e5331ca6be26830cf"
+  integrity sha512-DDDcV0uCgB2P/A0e8Vh8OB4zTpBVJyPMKdTuLF3XH1DUvA9p/s8VYomBVbilPRSXfUM64D1QxWdZuAGmnleZFA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.25"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.5.1":
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.5.1.tgz#c0adda8e9bb613051553a995bdb91f37a0180d92"
-  integrity sha512-g2IMSF/FzwCju36ILKa1d/QeJUtwuwFDyGBEvGliQPLOBXa360FYVm4wOXbhZHP1thrJYXCl4tll2jF51W1wwg==
+"@frontegg/types@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.6.0.tgz#1eacbb4c41cc792b6493d1bf2d6c6808c3b6307d"
+  integrity sha512-MYeOblQNJD5z73lIuATIuigbN+kvTBoCEFpNPil2kwLRz7zbLghFtPGRgofBTr5AzfNtJ634Nh+FEYczIk7vnA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.5.1"
+    "@frontegg/redux-store" "6.6.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.6.1":
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.6.1.tgz#8d9f22472aa39720f89acdaa1c0cb242448d7bd4"
-  integrity sha512-RbXJafRnumCgg+qe/gJPLBofzwNNoaM4yf/HZ4gdIP0R5+4cXhTSIk7qTVkXythei0JLOxrkFNs9etKTNPEZNQ==
+"@frontegg/js@6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.7.0.tgz#7a17ff6a27957e7fc53a208eaee8d0f9bb0b8f20"
+  integrity sha512-5Amdbbzdfql5W5dgZxMxzRpMuFqv3hXgyIoRoaADec0dYG/rmEbssQ+lmdneprsPjZrNL0mEw5P4Mt2Z4SmTWQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.6.1"
+    "@frontegg/types" "6.7.0"
 
-"@frontegg/redux-store@6.6.1":
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.6.1.tgz#6dd1a3adf484d8fe227c965ab6257b6966cd9082"
-  integrity sha512-WlkzUNFKFXynLg83VPUtOZuHntubpVYeHOlB9c69G2+sHnuIoyNNsTWIYQIS3tjpv7MdSN9/rOUBsbeMx28dTg==
+"@frontegg/redux-store@6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.7.0.tgz#bfa6d176c3aacac002a6d7a2f5e2907ae6c5f05a"
+  integrity sha512-XkVOcc13yABCcPrY/MyjuWPMaKdxI/qJfwmie3qRlsNT36W3J2q3a3/P9B0FbccZuhucguIrXE82a0BWZNdyfw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.25"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.6.1":
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.6.1.tgz#5e94809c61031e6efd7ea5843b48f5206329c41a"
-  integrity sha512-XpHVrrmSBIeOpJlVqYZeHeu6b/8Slkm0VmoOtvaXOIyzfiA6lc5VXXKjhZj0sZ7SaDoarq6NDMOhCavD6Xg9tg==
+"@frontegg/types@6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.7.0.tgz#5585679d3c27a23aa2dd920a9ca5d42cf5d140d1"
+  integrity sha512-TwoeFS97j3JWedNOYeBKQF9tkmOZVez/hbrTMU/4EVXmJPDA4CeeLFjFb2Eu4flr1X9DkwQUkCbQyICwWEroeg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.6.1"
+    "@frontegg/redux-store" "6.7.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.5.0.tgz#939dee7771722d5d13b153834ba5e66c97b0d5fe"
-  integrity sha512-LP/c7iQfe7NjOjvCgs73bwg6Qyv5Jj2K41hJ+/Mff7URu/SuUEzquUjhELJbUU48VSEpJa19HivxOyXR3b224Q==
+"@frontegg/js@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.5.1.tgz#8f8b7b2eb582f317338591096b9c03519887cc93"
+  integrity sha512-CugtQhVGyLgcgTX/8hJEXH1KsO/ZzanhxUR+PrflmAxqWkh2KFRMRDx7FFPJz3vLIL4VdwwX5oVhGbK4usXU4g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.5.0"
+    "@frontegg/types" "6.5.1"
 
-"@frontegg/redux-store@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.5.0.tgz#8d05872f4ee4d1dd47276725004f5d7078bf9902"
-  integrity sha512-hNX0X2YS96uFElcgBcXvLPCIxjQHo8O1SpN5cia4tQnHK43E8VBWPInNmwfV9ZedmtH7E1ZHNwf2hy08WnVL8A==
+"@frontegg/redux-store@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.5.1.tgz#9cb4813eb1d8cb0ba02257adae8ca70aa2d0eebb"
+  integrity sha512-iIRXTomE5+wNyVXyadZoFPyY4Izc1JQNouHhGoDh762S9TSD2gfzGQa5dixEZbJALurh1/RBZIJjGAFItuQO8A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.25"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.5.0.tgz#f31c0e99e817c23c21cab1bbb07fcd4934ac723e"
-  integrity sha512-Wj+Ps3r0UApwoeBpOQbBwsqZ39WTWg7tGUbuzZBGukBqLFwxIZGuTnhaZH973wmyrLW/BJlhZG1lO+dBEsodLA==
+"@frontegg/types@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.5.1.tgz#c0adda8e9bb613051553a995bdb91f37a0180d92"
+  integrity sha512-g2IMSF/FzwCju36ILKa1d/QeJUtwuwFDyGBEvGliQPLOBXa360FYVm4wOXbhZHP1thrJYXCl4tll2jF51W1wwg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.5.0"
+    "@frontegg/redux-store" "6.5.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.6.0.tgz#f2517fda524a3c56df742fe48f5b52f68e4e353d"
-  integrity sha512-RsnonFO+sx2F6ANRTKf/SP7WOKaHd1tlBjRqpC1fa/Pvzuvv73+vAUNtpbY6lihJVNQVpt+R4keadDXXEa9P0w==
+"@frontegg/js@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.6.1.tgz#8d9f22472aa39720f89acdaa1c0cb242448d7bd4"
+  integrity sha512-RbXJafRnumCgg+qe/gJPLBofzwNNoaM4yf/HZ4gdIP0R5+4cXhTSIk7qTVkXythei0JLOxrkFNs9etKTNPEZNQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.6.0"
+    "@frontegg/types" "6.6.1"
 
-"@frontegg/redux-store@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.6.0.tgz#24309ea1c4de4abe7691b02e5331ca6be26830cf"
-  integrity sha512-DDDcV0uCgB2P/A0e8Vh8OB4zTpBVJyPMKdTuLF3XH1DUvA9p/s8VYomBVbilPRSXfUM64D1QxWdZuAGmnleZFA==
+"@frontegg/redux-store@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.6.1.tgz#6dd1a3adf484d8fe227c965ab6257b6966cd9082"
+  integrity sha512-WlkzUNFKFXynLg83VPUtOZuHntubpVYeHOlB9c69G2+sHnuIoyNNsTWIYQIS3tjpv7MdSN9/rOUBsbeMx28dTg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.25"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.6.0.tgz#1eacbb4c41cc792b6493d1bf2d6c6808c3b6307d"
-  integrity sha512-MYeOblQNJD5z73lIuATIuigbN+kvTBoCEFpNPil2kwLRz7zbLghFtPGRgofBTr5AzfNtJ634Nh+FEYczIk7vnA==
+"@frontegg/types@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.6.1.tgz#5e94809c61031e6efd7ea5843b48f5206329c41a"
+  integrity sha512-XpHVrrmSBIeOpJlVqYZeHeu6b/8Slkm0VmoOtvaXOIyzfiA6lc5VXXKjhZj0sZ7SaDoarq6NDMOhCavD6Xg9tg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.6.0"
+    "@frontegg/redux-store" "6.6.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,39 +1138,39 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.7.0.tgz#7a17ff6a27957e7fc53a208eaee8d0f9bb0b8f20"
-  integrity sha512-5Amdbbzdfql5W5dgZxMxzRpMuFqv3hXgyIoRoaADec0dYG/rmEbssQ+lmdneprsPjZrNL0mEw5P4Mt2Z4SmTWQ==
+"@frontegg/js@6.8.1":
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.1.tgz#4998cb40ed84412cded17f364dffb15b834dca27"
+  integrity sha512-S9Pz4hYGXNUGsHboqnxK63US8yNXaYUO7P2lZISFzXD/0ifgwfBXafXXrZO3NWNGBhwr151rgFnxQBz1FRAk4A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.7.0"
+    "@frontegg/types" "6.8.1"
 
-"@frontegg/redux-store@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.7.0.tgz#bfa6d176c3aacac002a6d7a2f5e2907ae6c5f05a"
-  integrity sha512-XkVOcc13yABCcPrY/MyjuWPMaKdxI/qJfwmie3qRlsNT36W3J2q3a3/P9B0FbccZuhucguIrXE82a0BWZNdyfw==
+"@frontegg/redux-store@6.8.1":
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.1.tgz#e199e4b6a5091e42fbe97cfedea45736cddb981c"
+  integrity sha512-3ArBUnTqdnGtXwLC+c5q0KZfzNzBYCSxXokyHyEckBgmYMQL4+fuCkRr2LFJZ/9YLQIAthfElKb+3uevomLbfA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.25"
+    "@frontegg/rest-api" "3.0.26"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.25":
-  version "3.0.25"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.25.tgz#89e650953681349fc58a682d3bbbf413623fca68"
-  integrity sha512-OKZvGxquK5ZdwYSLwacUluWzoHf6OvmjnP/6u/EDvxBcQ8FhRujp7x8kxMuUmkF5SoT0hXLnCr/qQy1vAIDsjw==
+"@frontegg/rest-api@3.0.26":
+  version "3.0.26"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.26.tgz#66dbba5aecc4ea0252dfd61d403b08fb65c57cb6"
+  integrity sha512-8NpyHVczanzwKWaP4zLSIBqdfiqE6qwExj6QRbH9H+mcY9cIJ0+SKoda41J4N1HOmacdypSZ9gqnDm5Ns2FoAw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.7.0.tgz#5585679d3c27a23aa2dd920a9ca5d42cf5d140d1"
-  integrity sha512-TwoeFS97j3JWedNOYeBKQF9tkmOZVez/hbrTMU/4EVXmJPDA4CeeLFjFb2Eu4flr1X9DkwQUkCbQyICwWEroeg==
+"@frontegg/types@6.8.1":
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.1.tgz#4348e74250c687a2e2c4ecb0752e94229560c3f9"
+  integrity sha512-w5srGzLmoGoD8/KElY4GRIBub0LBYDeXiDJR5fDi3svTVyLFjtKaoRyR1A0WvlOCWtY4N9PIzR1xwvO2/dPOMg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.7.0"
+    "@frontegg/redux-store" "6.8.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.8.0:
- [FR-8269](https://frontegg.atlassian.net/browse/FR-8269) - update document title when visiting auth routes - [f7bac4ba](https://github.com/frontegg/admin-box/pulls?q=f7bac4ba)
- [FR-8930](https://frontegg.atlassian.net/browse/FR-8930) - ip restrictions - [3f38c464](https://github.com/frontegg/admin-box/pulls?q=3f38c464)
- [FR-8691](https://frontegg.atlassian.net/browse/FR-8691) - fix he - [9ae5d8a1](https://github.com/frontegg/admin-box/pulls?q=9ae5d8a1)
- [FR-8691](https://frontegg.atlassian.net/browse/FR-8691) - fix login mfa text - [1c8a68ac](https://github.com/frontegg/admin-box/pulls?q=1c8a68ac)

### AdminPortal 6.7.0:
- 

### AdminPortal 6.6.1:
- [FR-9085](https://frontegg.atlassian.net/browse/FR-9085) - fix hash routing - [01b308ef](https://github.com/frontegg/admin-box/pulls?q=01b308ef)

### AdminPortal 6.6.0:
- [FR-9085](https://frontegg.atlassian.net/browse/FR-9085) - fix hash routing - [73ce3b18](https://github.com/frontegg/admin-box/pulls?q=73ce3b18)