### PR TITLE
Update Frontegg AdminPortal to 6.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.9.0",
+    "@frontegg/js": "6.9.1",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.9.1",
+    "@frontegg/js": "6.10.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.9.0",
+    "@frontegg/js": "6.9.1",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.9.1",
+    "@frontegg/js": "6.10.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.9.0.tgz#05e0c9fd3decc4271af568cec6ca9a659271109f"
-  integrity sha512-pE5GhgMtbwKyJaA/gHSFsKl6fa6ClL2EBKTuRJvAqN5hTnjxUiMc13NdL2KcPqG+jnvK+qz2om6Z4/t4bK3cgQ==
+"@frontegg/js@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.9.1.tgz#eb5aca3c7a2df5e601f8a06b1c8d2f5af466e858"
+  integrity sha512-3rC+qhDtYYIkuDDGAYyoplZUwgnlS7HmQJ6eOr0/CFQsDI9ruCsCKUPh1Rtntr/YyaN+3aPuHNX1zI57og0sfQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.9.0"
+    "@frontegg/types" "6.9.1"
 
-"@frontegg/redux-store@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.9.0.tgz#67e042c978e69fd5e9f09c275e5fb2be30af3c68"
-  integrity sha512-qbfgrj2IKPsa/LnPFjSpsKy5yC0I9aGWWlhmKkmsP5ZezdskhVDKFlTQEXpDwHHQc/KUrw/0LBjziI3QEp6Q6w==
+"@frontegg/redux-store@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.9.1.tgz#8b27ba7f8bfabc2c2234da2c403127daaccc7b2a"
+  integrity sha512-uFuF8GuiGoVOL9NSoiPRLv5dxZsaeRI3/WpToxwHxhmZsvrmIqLB/9uoNBXxsUvdgBN0yqbJdHb4FNHKnNxzzA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.26"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.9.0.tgz#0dd5a8d92848c97393d0f8ea69ad2d335d8c325c"
-  integrity sha512-Twx2H1oyS15V98Dl6kP1u8x/4D4+qls17j+UwaZFBKsBfkD3J1Wd4I1segRuOGWzzoRqFsEClLkfBzqgVnsBrw==
+"@frontegg/types@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.9.1.tgz#42b53741263962316ae04c4c3dd4994b8d9721e6"
+  integrity sha512-h6uHXZDx9MUj775Y4Wdx4+SgLstmXJrStHsvakKizJyaDlz1mS6BTdBguo5UTTStkg6BmzwJcm3ZtZ1Yu5i+Nw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.9.0"
+    "@frontegg/redux-store" "6.9.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.2.tgz#5925e95d8d89b9392a86be3787db78410754f488"
-  integrity sha512-IEk6x2ZrRJGVqiwH1RJNpmuPa9hXZHvSOUWRPgCIyy8xtrH3XgUkEwNbEdv9QfG0RbhJcyGe5uD3Oh9XFHWOxg==
+"@frontegg/js@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.9.0.tgz#05e0c9fd3decc4271af568cec6ca9a659271109f"
+  integrity sha512-pE5GhgMtbwKyJaA/gHSFsKl6fa6ClL2EBKTuRJvAqN5hTnjxUiMc13NdL2KcPqG+jnvK+qz2om6Z4/t4bK3cgQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.8.2"
+    "@frontegg/types" "6.9.0"
 
-"@frontegg/redux-store@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.2.tgz#4d4aa63ad7735a3940f2dbbb6d267b9ad271677c"
-  integrity sha512-50qMR2wxx0TBo+Ve74AxBx6eUiCyxJBYmZfLd8JQXGmZOYxNyeWtdOMrYRe6M/mJQi52TDKXZDS74gislfNTUQ==
+"@frontegg/redux-store@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.9.0.tgz#67e042c978e69fd5e9f09c275e5fb2be30af3c68"
+  integrity sha512-qbfgrj2IKPsa/LnPFjSpsKy5yC0I9aGWWlhmKkmsP5ZezdskhVDKFlTQEXpDwHHQc/KUrw/0LBjziI3QEp6Q6w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.26"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.2.tgz#5271752c908dc665aa06cca4db09de18c6dec825"
-  integrity sha512-+GkRM+5NZNgXvdePIC/7DL4yOR3fxa84OFFFQZe3JFN45jgoHzwSpiK/IK3UW6u1bfNkHb1N4wq7VureGsYRDQ==
+"@frontegg/types@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.9.0.tgz#0dd5a8d92848c97393d0f8ea69ad2d335d8c325c"
+  integrity sha512-Twx2H1oyS15V98Dl6kP1u8x/4D4+qls17j+UwaZFBKsBfkD3J1Wd4I1segRuOGWzzoRqFsEClLkfBzqgVnsBrw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.8.2"
+    "@frontegg/redux-store" "6.9.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.10.0:
- [FR-7960](https://frontegg.atlassian.net/browse/FR-7960) - missing deps in location cell - [9c07483c](https://github.com/frontegg/admin-box/pulls?q=9c07483c)

### AdminPortal 6.9.1:
- [FR-9119](https://frontegg.atlassian.net/browse/FR-9119) - add api show terms and conditions in activate account - [d13ce32c](https://github.com/frontegg/admin-box/pulls?q=d13ce32c)
- [FR-9166](https://frontegg.atlassian.net/browse/FR-9166) - add future test plan sso and subscription - [69221469](https://github.com/frontegg/admin-box/pulls?q=69221469)