### PR TITLE
Update Frontegg AdminPortal to 6.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.11.0",
+    "@frontegg/js": "6.12.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.12.0",
+    "@frontegg/js": "6.13.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.10.1",
+    "@frontegg/js": "6.11.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.10.0",
+    "@frontegg/js": "6.10.1",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.10.1",
+    "@frontegg/js": "6.11.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.12.0",
+    "@frontegg/js": "6.13.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.11.0",
+    "@frontegg/js": "6.12.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.10.0",
+    "@frontegg/js": "6.10.1",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.11.0.tgz#2531bfd06111e9886060ab21e2ec61ecf18e46d5"
-  integrity sha512-hvXo4B6qjGEhKvWOunYZLityJGtpzi7tyFnECXKkW4nJmoa5TVNv7hNAWAxV5EvRm6ux1u+IvXkmggTnXn68fA==
+"@frontegg/js@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.12.0.tgz#744d660dc7aa8016a4310678b22730f041b96f87"
+  integrity sha512-sM3t0ERbt0O0NqhKEhVVFF0IYSDWHSFUTDCnIamV1V7jvkmoH4foPyt4pr0jU0tJ1hVZN8JZyJo3As470izXvw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.11.0"
+    "@frontegg/types" "6.12.0"
 
-"@frontegg/redux-store@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.11.0.tgz#f37418a9fc6ed1698e37812b209e0ee96c37cde5"
-  integrity sha512-SegaQoJcl21HzDYGibUOj8WwWxSgZe0pjcm16AeSw+b8zprO/O7AAUeZqO7+Jd95q4GDriRJQ3eUYm07pkIdGQ==
+"@frontegg/redux-store@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.12.0.tgz#eb735d51deafc2e99095b12874be2cbebb8cbbd6"
+  integrity sha512-Jai+vJIKCMh4YKRt0e+ZqEDi4AMHOm018lDfQTiiuUNbXzylqRYmv8H30VlcGBmD108StD74/nDCtHWXuEDkEA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.27"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.11.0.tgz#5789886567df57403c580ee82dd62b96dafcf6c5"
-  integrity sha512-GJZSkcOIMwpw4izDRtRy7NLqrNbx8ka2fFlnGZ6rdCaTCTBRfJpyMAmCQXId83McaHVufljTe1dXeOIShMTbJQ==
+"@frontegg/types@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.12.0.tgz#1bcdf7e89c4320864b3d4057ba2f68a4344cc308"
+  integrity sha512-eIJZTdOZS6v8LTWi4OoPL5Dzj9HpaWht6m7LWrCfe3kBMzZHKxgSznn2EhCiaDJ3yXoAA1B1REOCGMwnitjSmg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.11.0"
+    "@frontegg/redux-store" "6.12.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.10.1":
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.10.1.tgz#f00617485a0e9bab15e59be5d614399b8ff00f45"
-  integrity sha512-oh1U858uLchRnr5+D82LXqmW62GAxnUqI9XFVADnsXpasTgaMYLQ1JuplfSlPbzUbVlgsFevt1HUv4hLPlqtEg==
+"@frontegg/js@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.11.0.tgz#2531bfd06111e9886060ab21e2ec61ecf18e46d5"
+  integrity sha512-hvXo4B6qjGEhKvWOunYZLityJGtpzi7tyFnECXKkW4nJmoa5TVNv7hNAWAxV5EvRm6ux1u+IvXkmggTnXn68fA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.10.1"
+    "@frontegg/types" "6.11.0"
 
-"@frontegg/redux-store@6.10.1":
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.10.1.tgz#47813ea995bb5bcdedd522d86fbb2c204ebb8d68"
-  integrity sha512-PzULjn1zbcH4xbBJUUuH/7IO6LLMPAvFFymqx/SEgSc8unfMtETJPvvLUDIr+6Zy8FT3rBfMtECpkdRdERpVgw==
+"@frontegg/redux-store@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.11.0.tgz#f37418a9fc6ed1698e37812b209e0ee96c37cde5"
+  integrity sha512-SegaQoJcl21HzDYGibUOj8WwWxSgZe0pjcm16AeSw+b8zprO/O7AAUeZqO7+Jd95q4GDriRJQ3eUYm07pkIdGQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.27"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.10.1":
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.10.1.tgz#277e6e46d2f492730a3d40ab68b521323ef6f96d"
-  integrity sha512-2Z5XAwwmXr9J+OxGUEaRTlpuwgFplP/TPYnwuJ2FAEKBVA2Rm9P3nYAowZUsvztcu8CeDh6UoE4KTh3T7wYSdw==
+"@frontegg/types@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.11.0.tgz#5789886567df57403c580ee82dd62b96dafcf6c5"
+  integrity sha512-GJZSkcOIMwpw4izDRtRy7NLqrNbx8ka2fFlnGZ6rdCaTCTBRfJpyMAmCQXId83McaHVufljTe1dXeOIShMTbJQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.10.1"
+    "@frontegg/redux-store" "6.11.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,39 +1138,39 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.12.0":
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.12.0.tgz#744d660dc7aa8016a4310678b22730f041b96f87"
-  integrity sha512-sM3t0ERbt0O0NqhKEhVVFF0IYSDWHSFUTDCnIamV1V7jvkmoH4foPyt4pr0jU0tJ1hVZN8JZyJo3As470izXvw==
+"@frontegg/js@6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.13.0.tgz#619d7e445dbb2519fc016868ecfef145bbc4c3f4"
+  integrity sha512-LGYbkYE265eSdpDY4FtU+R6m2t9qqmUx1jCEQURNMli62psQgYLwMui/Sz6uW82JNmOXLaJhZ/pOtmIQkoSIRA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.12.0"
+    "@frontegg/types" "6.13.0"
 
-"@frontegg/redux-store@6.12.0":
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.12.0.tgz#eb735d51deafc2e99095b12874be2cbebb8cbbd6"
-  integrity sha512-Jai+vJIKCMh4YKRt0e+ZqEDi4AMHOm018lDfQTiiuUNbXzylqRYmv8H30VlcGBmD108StD74/nDCtHWXuEDkEA==
+"@frontegg/redux-store@6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.13.0.tgz#7a279d3378c709b45db3893dcc4d1fd10d2925a4"
+  integrity sha512-DnbdPyv1Sr9FIeEO8XFJFrNe+CrIpTiFBQOZhy8LMsT9d8voTz9w7BQr/OYkaBcqWT3u7alSh6ewnu2Yl49MCg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.27"
+    "@frontegg/rest-api" "3.0.29"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.27":
-  version "3.0.27"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.27.tgz#3dd79981775d2b528769704f2b9ea6656d9b2c86"
-  integrity sha512-qjAP0sP62GjgZR1Kl7/A/SwM2vIfdKRhcHGOfWFTwDwRavVhwtkTX1gGZsopjDgI1u7fmkjJbFM7gh3tZWElJg==
+"@frontegg/rest-api@3.0.29":
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.29.tgz#66e4ede35eca6eb738ad27485d55b072aa420dad"
+  integrity sha512-+X8HUGexoTBLK9JhovCSDDxHGHUO105naDZmET3deIu/3NrYj76VQH9X2+IvmY/ozo7hsIUuutLXcOeCbbXfZA==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.12.0":
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.12.0.tgz#1bcdf7e89c4320864b3d4057ba2f68a4344cc308"
-  integrity sha512-eIJZTdOZS6v8LTWi4OoPL5Dzj9HpaWht6m7LWrCfe3kBMzZHKxgSznn2EhCiaDJ3yXoAA1B1REOCGMwnitjSmg==
+"@frontegg/types@6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.13.0.tgz#3f492d6e6355d13033115157bfb0fb3492faee05"
+  integrity sha512-cRZygMJeSYa7772zltsueSPbKe2uMml322pkX9q0FAR0KIPUo5yTuoZG/S7YxBYfFPlszqo+9pUhEcmD7LJA1w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.12.0"
+    "@frontegg/redux-store" "6.13.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.10.0.tgz#1deb19dae3c8dbf11b15f797fde467a258d4abc6"
-  integrity sha512-7idyEpb8tlh5z8IVy+kndTyt9Y6jKqG/981cFL0n8+keUl83GEhnn24mxse/Ej6NNsbAKHkgHKFHOSgkK4nJNQ==
+"@frontegg/js@6.10.1":
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.10.1.tgz#f00617485a0e9bab15e59be5d614399b8ff00f45"
+  integrity sha512-oh1U858uLchRnr5+D82LXqmW62GAxnUqI9XFVADnsXpasTgaMYLQ1JuplfSlPbzUbVlgsFevt1HUv4hLPlqtEg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.10.0"
+    "@frontegg/types" "6.10.1"
 
-"@frontegg/redux-store@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.10.0.tgz#22a2419dbc024b481e626f8cfabfb90943336ced"
-  integrity sha512-1mFF+QpXQL+ZaGCQVlsk3247pfgngIjGvHYSl1QNy/ax9ju/oeUJknn6Prk0uG8okQzUHgsz/oCRfUIM+8CvVA==
+"@frontegg/redux-store@6.10.1":
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.10.1.tgz#47813ea995bb5bcdedd522d86fbb2c204ebb8d68"
+  integrity sha512-PzULjn1zbcH4xbBJUUuH/7IO6LLMPAvFFymqx/SEgSc8unfMtETJPvvLUDIr+6Zy8FT3rBfMtECpkdRdERpVgw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.27"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.10.0.tgz#f1bfe9b614d145db417911e064ee12894a03ec3f"
-  integrity sha512-fnaDmKK3bet3pQNrNUjcbuuL9rQ7BDPz5CUKonY0qQP95d5kHp6QTFW0FRIRaPOfO88f+OTv9X4ekwkHqfNQSA==
+"@frontegg/types@6.10.1":
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.10.1.tgz#277e6e46d2f492730a3d40ab68b521323ef6f96d"
+  integrity sha512-2Z5XAwwmXr9J+OxGUEaRTlpuwgFplP/TPYnwuJ2FAEKBVA2Rm9P3nYAowZUsvztcu8CeDh6UoE4KTh3T7wYSdw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.10.0"
+    "@frontegg/redux-store" "6.10.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.13.0:
- 

### AdminPortal 6.12.0:
- [FR-9168](https://frontegg.atlassian.net/browse/FR-9168) - Add ready / loginWithRedirect - [fdfd671b](https://github.com/frontegg/admin-box/pulls?q=fdfd671b)
- [FR-8643](https://frontegg.atlassian.net/browse/FR-8643) - fix changing background color for input in preview mode - [f6429b84](https://github.com/frontegg/admin-box/pulls?q=f6429b84)

### AdminPortal 6.11.0:
- 

### AdminPortal 6.10.1:
- [FR-9196](https://frontegg.atlassian.net/browse/FR-9196) - Login box builder mode example app - [89e73ce2](https://github.com/frontegg/admin-box/pulls?q=89e73ce2)
- [FR-8714](https://frontegg.atlassian.net/browse/FR-8714) - recaptcha fix - [beb8081c](https://github.com/frontegg/admin-box/pulls?q=beb8081c)