### PR TITLE
Update Frontegg AdminPortal to 6.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.36.0",
+    "@frontegg/js": "6.41.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.41.0",
+    "@frontegg/js": "6.42.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.36.0",
+    "@frontegg/js": "6.41.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.41.0",
+    "@frontegg/js": "6.42.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,39 +1138,39 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.36.0":
-  version "6.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.36.0.tgz#be93ab15f21094a451fac768020dfbde00681052"
-  integrity sha512-2Pbc12Ano4iNDeUt1U/2PFS+krBODBOsKZo2fzE80XdRo7wiysh/c0B09C+PUrksDZLY3iFvPVMUPys2+hBadA==
+"@frontegg/js@6.41.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.41.0.tgz#d45fd27e751d830c1b35c977665985dc3ab1be85"
+  integrity sha512-NXfU6/+nRe92oM5KgnnISZnUbE5vZ39iv0uIZX9JYJwUDolTCsB0CQOrs9BQHgUosHdmbshzgcZJ7SynYoBR8Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.36.0"
+    "@frontegg/types" "6.41.0"
 
-"@frontegg/redux-store@6.36.0":
-  version "6.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.36.0.tgz#2cd792292e81954a4cfa7b708e22af079ea1cfab"
-  integrity sha512-rkKQzsdDDwmganZP72KOZjX1soa5NdWM6TDD+XkJWP5t08uhRSYwfVoQAyEEzODuKDuHSj0g+kmNry6N0Jc8KA==
+"@frontegg/redux-store@6.41.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.41.0.tgz#18e21176951f3425659abe0450c4884a4c9b1fe0"
+  integrity sha512-UDtjXpIB3zhKbEgz6x8+yZeGVArLOESCkJ8bUpPRbM4bWW4/rCcwb7ujWSLSmDxqfwQh3tHU4AkmYq/MtAvAzA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.31"
+    "@frontegg/rest-api" "3.0.32"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.31":
-  version "3.0.31"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.31.tgz#ac2646ae73a81d32281b8140df58ad19e11bdc3a"
-  integrity sha512-hGgWW3TAfTWAucJlrq8D97vWkkmQtgvsdlHqq4l9Admd4JI4GikXEDAfsdDHA+kN7IesT5FydZlpvYYDtSK6lw==
+"@frontegg/rest-api@3.0.32":
+  version "3.0.32"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.32.tgz#fac182f8cb254245d13b5c4634034a978db798c2"
+  integrity sha512-H0l5+gTPGoALGM+K80ODkQJiv4aJS1aRYcZNdU0qWdnFU/1SWOyu7syNsBSmteha5/IytI/GiWhKtIg5Lt1Gdw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.36.0":
-  version "6.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.36.0.tgz#ee8e90a9c337d451af02e35ad3e007967cbaacfb"
-  integrity sha512-uvUt52hPk1lY1h2KR31weIU/clx9UvCMqecTXzHrrVHHrrzFRvUu7vFrCYzWx3kJVJzi/RV2VcnBN+yuXXc3tw==
+"@frontegg/types@6.41.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.41.0.tgz#680389a6990c6a2019f78e3d99cde292493b520b"
+  integrity sha512-YN/pzqGwcplydBltyYzVg/FQhOAUjuXaWe+31AYpCrT1T85w5A39FwGIwt2/8P4PHNHx023U4l9o/wBd7B2Uag==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.36.0"
+    "@frontegg/redux-store" "6.41.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-9186 - support ssr with session and refresh token
- FR-9614 - Add support for innerThemeProvider for admin portal pages and tabs

- FR-9186 - fix pipeline