### PR TITLE
Update Frontegg AdminPortal to 6.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.44.0",
+    "@frontegg/js": "6.45.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.43.0",
+    "@frontegg/js": "6.44.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.42.0",
+    "@frontegg/js": "6.43.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.43.0",
+    "@frontegg/js": "6.44.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.44.0",
+    "@frontegg/js": "6.45.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.42.0",
+    "@frontegg/js": "6.43.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,39 +1138,39 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.42.0":
-  version "6.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.42.0.tgz#1cd6fdb1085a160a0802480423a17bf1cd48d6b8"
-  integrity sha512-QtxSX0qe16b+vdwI3ZeaIcC1vMGhf9VAAPdx7tLpWF1xxcUfAHYlXQtKYZFqQ+ydGC6Dpsy2IRSohd8Ag6CsPQ==
+"@frontegg/js@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.43.0.tgz#6ca7194ed87527a3f22ad335a7b4619832af4dc0"
+  integrity sha512-0HhBhXkM6EZCfUVJE2YIaK3ZsO7TQ1ALIJY1yofZJ9tkQR/j/MeBu7sVP5TDBeWzI7EuxYdjRYPEJI33VCQ3wQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.42.0"
+    "@frontegg/types" "6.43.0"
 
-"@frontegg/redux-store@6.42.0":
-  version "6.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.42.0.tgz#f492dfb733669e6e88409197f831b9016d58bebb"
-  integrity sha512-tWKs8t/i6IypDgOJix0udE6Y1YKLypWInXTL8Bby1hlOpUN668YVznpvv5b5EE7iQ/KFCpqJglwpqLslKdDZAA==
+"@frontegg/redux-store@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.43.0.tgz#364977e4a33c50ddbde406d90ecc903b109d2fc4"
+  integrity sha512-fI4mweHERaXiDtr3yISkDk7z1EofAbu9VqhirOC5p4GGscF6escJR8iBgx31cG91r2tsMkfisSk3MB9wGpTtPA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.32"
+    "@frontegg/rest-api" "3.0.34"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.32":
-  version "3.0.32"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.32.tgz#fac182f8cb254245d13b5c4634034a978db798c2"
-  integrity sha512-H0l5+gTPGoALGM+K80ODkQJiv4aJS1aRYcZNdU0qWdnFU/1SWOyu7syNsBSmteha5/IytI/GiWhKtIg5Lt1Gdw==
+"@frontegg/rest-api@3.0.34":
+  version "3.0.34"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.34.tgz#f023221ceced8ad34ab7c62dc8a30288946f6b0d"
+  integrity sha512-hJWVB0ebEAFjQ4kbxngvkfq5QokPTPMSl3OP/Kv+VXbV6A76B9aa82uE7xgC5y/lEr2kldQ6UoGRdtIxZtLBsA==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.42.0":
-  version "6.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.42.0.tgz#d52bda51b0b9219cfad7b51185cf23cd4c6e1752"
-  integrity sha512-fEukLyK9ZO3kDlYNKxZ0/6Du88m3fJi2IkS9ecmy39thR9P2wxzUqKqBR4/eMw5pafyy5tHpzZfMwjmWKx/acA==
+"@frontegg/types@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.43.0.tgz#64ca440c705ffb270054ed556d2ad4f6e887fc3c"
+  integrity sha512-EaDHni0EkWacQjgmJtk8Wb+jLTX0H/EbDAvdJfA5R0OnP9+OcUOuIaxXUp/b+G+almBagwXBQFa87cKCjsmxbA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.42.0"
+    "@frontegg/redux-store" "6.43.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.44.0":
-  version "6.44.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.44.0.tgz#e6b987c0040737b340000eb49c26c2751ec42508"
-  integrity sha512-ahkkG17ILWS9NEQwITsKj5H3g4woD/xtWP13SwLj/uw2v+GJgOq1V0MjYPExQauoXl3WXa6NLUNBL/WnMVi+2A==
+"@frontegg/js@6.45.0":
+  version "6.45.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.45.0.tgz#b0e142c956e70a69e518d22cc2426adead62344d"
+  integrity sha512-TYg4Xs/lPilVnWhtkJYYzw7yauQe9H0qUyyG2pilh/ZzRVjqkclAAn4y+JAnEXfdnq66msYiSEtgO3Doz9+1Tg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.44.0"
+    "@frontegg/types" "6.45.0"
 
-"@frontegg/redux-store@6.44.0":
-  version "6.44.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.44.0.tgz#84a24b0bf7e103bd3e02fe88ee1b114fc43e20f0"
-  integrity sha512-11RuxMxAFCoO9SjTLce6FHo7Zck40Vg+eaknE68bvERVoQ/piTAkQeo3bqmhjdMy3wmBrT/saetPrZ5hNqR/mA==
+"@frontegg/redux-store@6.45.0":
+  version "6.45.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.45.0.tgz#3b5f02cca538aee26bd4d8e9f8f6419781646e35"
+  integrity sha512-NcJwyMEYKcD86f5R04zGJJ6waizjkg4tXuy3pKvrTWPFDzzErWni03iK2E7fodQ8OQNpoQSIcf4YalZ9lDwJTg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.34"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.44.0":
-  version "6.44.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.44.0.tgz#e2c940a6f116a193d51e352b6d9ab68340e450d6"
-  integrity sha512-w4TDKGYuZKcDB+Ij4vjJpF4M9JGBuIcHYSsuQTJ+5VmS/72vJAzvUajmif6qvMHe+CQsXEkIgwUGS4tQR9Knog==
+"@frontegg/types@6.45.0":
+  version "6.45.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.45.0.tgz#0eaf52f5a3317e9c274d002ce3710dde15393809"
+  integrity sha512-dycLkkRRWtmWuq8hckvrDdqAJl2UElq3lxb4fGSjCAUwYUeKHy0k7jI1D6O4WQmNzpLFNy3ejiYpz/9nE7uGjQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.44.0"
+    "@frontegg/redux-store" "6.45.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.43.0":
-  version "6.43.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.43.0.tgz#6ca7194ed87527a3f22ad335a7b4619832af4dc0"
-  integrity sha512-0HhBhXkM6EZCfUVJE2YIaK3ZsO7TQ1ALIJY1yofZJ9tkQR/j/MeBu7sVP5TDBeWzI7EuxYdjRYPEJI33VCQ3wQ==
+"@frontegg/js@6.44.0":
+  version "6.44.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.44.0.tgz#e6b987c0040737b340000eb49c26c2751ec42508"
+  integrity sha512-ahkkG17ILWS9NEQwITsKj5H3g4woD/xtWP13SwLj/uw2v+GJgOq1V0MjYPExQauoXl3WXa6NLUNBL/WnMVi+2A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.43.0"
+    "@frontegg/types" "6.44.0"
 
-"@frontegg/redux-store@6.43.0":
-  version "6.43.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.43.0.tgz#364977e4a33c50ddbde406d90ecc903b109d2fc4"
-  integrity sha512-fI4mweHERaXiDtr3yISkDk7z1EofAbu9VqhirOC5p4GGscF6escJR8iBgx31cG91r2tsMkfisSk3MB9wGpTtPA==
+"@frontegg/redux-store@6.44.0":
+  version "6.44.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.44.0.tgz#84a24b0bf7e103bd3e02fe88ee1b114fc43e20f0"
+  integrity sha512-11RuxMxAFCoO9SjTLce6FHo7Zck40Vg+eaknE68bvERVoQ/piTAkQeo3bqmhjdMy3wmBrT/saetPrZ5hNqR/mA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.34"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.43.0":
-  version "6.43.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.43.0.tgz#64ca440c705ffb270054ed556d2ad4f6e887fc3c"
-  integrity sha512-EaDHni0EkWacQjgmJtk8Wb+jLTX0H/EbDAvdJfA5R0OnP9+OcUOuIaxXUp/b+G+almBagwXBQFa87cKCjsmxbA==
+"@frontegg/types@6.44.0":
+  version "6.44.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.44.0.tgz#e2c940a6f116a193d51e352b6d9ab68340e450d6"
+  integrity sha512-w4TDKGYuZKcDB+Ij4vjJpF4M9JGBuIcHYSsuQTJ+5VmS/72vJAzvUajmif6qvMHe+CQsXEkIgwUGS4tQR9Knog==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.43.0"
+    "@frontegg/redux-store" "6.44.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-9792 - fix theme chunk
- FR-9784 - pass merged palette to themes json
- FR-9777 - add option to color hover in navigation
- FR-9235 - Fix AndorrA typo in country dropdown
- FR-9725 - fix select popup
- FR-9771 - refactor toggle button
- FR-9749 - fix big titles on speedy login thumb nail mode
- FR-9730 - select tree for dark theme
- FR-9721 - add possibilities to security tabs for dark theme
- FR-9696 - fix responsiveness on builder preview
- FR-8402 - Hide sign up form when there is not local authentication same as we do in the login flow
- FR-9652 - mock flags
- FR-9667 - fix copy of restrictions
- FR-9677 - add slack provider to social login types
- FR-8849 - Resend invite and activate your account calls fix
- FR-9260 - Creating Custom webhook on the Admin Portal is sent with the evnetId and not with the eventKey

- FR-9665 - Support logout from hosted login in vanilla.js via app instance
- FR-9662 - pagination in dark them

- FR-9664 - update @frontegg/rest-api
- FR-9661 - fix chips in dark them
- FR-9653 - fix hide fields session management
- FR-9659 - inherit button dark them
- FR-9655 - fix dialog and select dark them
- FR-8948 - Fix - clean error message from sign up page when visiting it again
- FR-9624 - typo + snyk git ignore
- FR-9629 - typography should be white in dark theme
- FR-9625 - empty table in dark theme
- FR-9631 - resize the login box when logo is null
- FR-9176 - hide fields security and account details pages
- FR-8714 - Fix ReCaptcha timeout