### PR TITLE
Update Frontegg AdminPortal to 6.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.48.0",
+    "@frontegg/js": "6.49.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.48.0",
+    "@frontegg/js": "6.49.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",


### PR DESCRIPTION
- FR-9914 - Move initial api calls to NextJS server-side before the first render
- FR-9887 - OTC digits are not visible on mobile devices
- FR-9860 - mfa devices management
- FR-9418 - invite email bulk