### PR TITLE
Update Frontegg AdminPortal to 6.83.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.81.0",
+    "@frontegg/js": "6.82.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.82.0",
+    "@frontegg/js": "6.83.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.80.0",
+    "@frontegg/js": "6.81.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.81.0",
+    "@frontegg/js": "6.82.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.80.0",
+    "@frontegg/js": "6.81.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.82.0",
+    "@frontegg/js": "6.83.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.82.0":
-  version "6.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.82.0.tgz#926120ed62d5400447b537beaa403b0c7bc5a648"
-  integrity sha512-jwzdCaHVsDn4cwA2FrMTZ3Mcw5vMcZJTjGe7KHSRrLH7Y6tWM4ANb7Kw804BGhLPUMq7AIz0I3gp0rhCy5FJNA==
+"@frontegg/js@6.83.0":
+  version "6.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.83.0.tgz#1ff8a4a4430924f811d5bf7436e2665673632174"
+  integrity sha512-Mb8W70bN8KVO75TQk/J64Zm5XDN5wuHIVZZHyogwMBPEfQ3PdOcPAMCsuH7BZ4+/rN6MI05qtkJIr49F+vsjeQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.82.0"
+    "@frontegg/types" "6.83.0"
 
-"@frontegg/redux-store@6.82.0":
-  version "6.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.82.0.tgz#6d11b1745efb3fb2844ac2a4578d9291e0fff1ef"
-  integrity sha512-XWUhewhH00ioNYT2MLFpxna8wQhrrJZ94b6UVezXgywgfOn1LlJf0yfO1G03XTBuqi9GKNzE73g8eHx92ccgaA==
+"@frontegg/redux-store@6.83.0":
+  version "6.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.83.0.tgz#0c1056038aaf35521856f087c24c3c71454f15bc"
+  integrity sha512-iGEFkkgv8qqmgWsaKYCVRxwAp7xY46AONrryqoK1mMVJZPW+NfcqzoxcxCb86PqmU0FSEdmoKwEW1uAfcF9lIw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.95"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.82.0":
-  version "6.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.82.0.tgz#d28e5ee32f00465d61b644e7c3232e30ac18c1b0"
-  integrity sha512-Hd3DhInOO33lG6Ga+mDC/B6jjUQbr9Qww5dpPe34m7EvAe0fSTxIkdd+vBclqrlGSh8ELRos4n22zsI6d/70TA==
+"@frontegg/types@6.83.0":
+  version "6.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.83.0.tgz#19260d5e56036e1d91275b5bcd0f9368ede0067c"
+  integrity sha512-ws7xee4DRsF0+7bNlw8Minj/rSG9mH33y2yKb4K0Tq6cNKXDruz7qgcFEXS2zMrGNIWiepipUMBXFYG8w1aBcw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.82.0"
+    "@frontegg/redux-store" "6.83.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,18 +1138,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.81.0":
-  version "6.81.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.81.0.tgz#9f5b40551c216e781b26ddfd997a4bba8166dbf5"
-  integrity sha512-zby1tme7DZrLjML7gyPVtr9ayb4PcPLT0wkSjQSZIZm2EnAsUQVtH0EYLn1mxXhqjKFGKLBPLB+Kkz+PB1xMYQ==
+"@frontegg/js@6.82.0":
+  version "6.82.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.82.0.tgz#926120ed62d5400447b537beaa403b0c7bc5a648"
+  integrity sha512-jwzdCaHVsDn4cwA2FrMTZ3Mcw5vMcZJTjGe7KHSRrLH7Y6tWM4ANb7Kw804BGhLPUMq7AIz0I3gp0rhCy5FJNA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.81.0"
+    "@frontegg/types" "6.82.0"
 
-"@frontegg/redux-store@6.81.0":
-  version "6.81.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.81.0.tgz#85e9783a05b4ea9a3073fa222d6d3f12b4dc763c"
-  integrity sha512-VAso06mTU3cC9il+7VYXeJDiU7Xb94qJrjIzGuYzv+EniIAMRx6HsGDRLA5YHDw8rvKUJw5FSZJw1nhc8Dyijw==
+"@frontegg/redux-store@6.82.0":
+  version "6.82.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.82.0.tgz#6d11b1745efb3fb2844ac2a4578d9291e0fff1ef"
+  integrity sha512-XWUhewhH00ioNYT2MLFpxna8wQhrrJZ94b6UVezXgywgfOn1LlJf0yfO1G03XTBuqi9GKNzE73g8eHx92ccgaA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.95"
@@ -1164,13 +1164,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.81.0":
-  version "6.81.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.81.0.tgz#a5dcba77f777bf8d9ed5d978b6b3018ddc558ee6"
-  integrity sha512-2Zqf617EdEPYrkH9qhiBe+aLEro77VzPXL/EeUL2yAXsSOdprRu1uMvsDlmdmUgCDqcsn3p4agUggMUjArIhlA==
+"@frontegg/types@6.82.0":
+  version "6.82.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.82.0.tgz#d28e5ee32f00465d61b644e7c3232e30ac18c1b0"
+  integrity sha512-Hd3DhInOO33lG6Ga+mDC/B6jjUQbr9Qww5dpPe34m7EvAe0fSTxIkdd+vBclqrlGSh8ELRos4n22zsI6d/70TA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.81.0"
+    "@frontegg/redux-store" "6.82.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,39 +1138,39 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.80.0":
-  version "6.80.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.80.0.tgz#4165185dd86b73e2d5bf558f4fabc15fdf04966b"
-  integrity sha512-1R6Xj4v4DHVDjO5rJK1keT1nUZdq9sJmqgmzy/CaxyOduLRlfXF+7/Ipo+gqVPu0dHHOd5fqbLztJACa39vgpA==
+"@frontegg/js@6.81.0":
+  version "6.81.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.81.0.tgz#9f5b40551c216e781b26ddfd997a4bba8166dbf5"
+  integrity sha512-zby1tme7DZrLjML7gyPVtr9ayb4PcPLT0wkSjQSZIZm2EnAsUQVtH0EYLn1mxXhqjKFGKLBPLB+Kkz+PB1xMYQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.80.0"
+    "@frontegg/types" "6.81.0"
 
-"@frontegg/redux-store@6.80.0":
-  version "6.80.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.80.0.tgz#588ed56283ab32a5163824207b5e7785a2a6444a"
-  integrity sha512-m7hST9rI5ni6N9a0ws0+/o1/wS3OSQ3lHwAjvzBA3u15DL83J5rL+WDWUv5IrZcxJF4nzy9SzxYC+fOCN+dLOw==
+"@frontegg/redux-store@6.81.0":
+  version "6.81.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.81.0.tgz#85e9783a05b4ea9a3073fa222d6d3f12b4dc763c"
+  integrity sha512-VAso06mTU3cC9il+7VYXeJDiU7Xb94qJrjIzGuYzv+EniIAMRx6HsGDRLA5YHDw8rvKUJw5FSZJw1nhc8Dyijw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.90"
+    "@frontegg/rest-api" "^3.0.95"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.90":
-  version "3.0.90"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.90.tgz#444da7e678acdc154647bc7c5be45fafc00d4f54"
-  integrity sha512-vqiLTuvJEy7aXTBzc8u3Mr248i+hzEE0Ro2om25hPRANO9Wnk4nmfmU+YDEknRKD81HuEeJXrjlIf1zoytoalQ==
+"@frontegg/rest-api@^3.0.95":
+  version "3.0.95"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.95.tgz#975174b797c38c164661ecfa83565d99135e7aca"
+  integrity sha512-uAiWsEY+OzLoU60N7ASGhpNZnUONQ/joywPSIDvgTIRuo229a0H/z++N1wBqG4a+Dw8UEc5FkenPjllVCeME7A==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.80.0":
-  version "6.80.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.80.0.tgz#0e1511187eaf86bf1029868ddddbcf68e13df7d9"
-  integrity sha512-L++3NBVujBLoGFA6+nLw22hM1Wk1uDl7+p9kP+nGWGs3rq+WcfntblzT+CG+utMrBYpuqjVmmqImP+f5XScOGQ==
+"@frontegg/types@6.81.0":
+  version "6.81.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.81.0.tgz#a5dcba77f777bf8d9ed5d978b6b3018ddc558ee6"
+  integrity sha512-2Zqf617EdEPYrkH9qhiBe+aLEro77VzPXL/EeUL2yAXsSOdprRu1uMvsDlmdmUgCDqcsn3p4agUggMUjArIhlA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.80.0"
+    "@frontegg/redux-store" "6.81.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-11247 - fix version branch 6.82

- FR-11065 - add passkeys mock ff
- FR-11189 - mfa authenticator app change input type
- FR-10821 - fix table color
- FR-11204 - add unit testing with jest
- FR-11139 - fix groups
- FR-11039 - fix groups dummy
- FR-11039 - ff groups
- FR-10530 - fix ff store name
- FR-11067 - error handling on profile image upload
- FR-11039 - extend users table with groups column

- FR-10530 - fix ff
- FR-10654 - Fix OIDC loading screen
- FR-10530 - fix ff store name
- FR-10530 - fix ff store name
- FR-10530 - change ff behavior  