### PR TITLE
Update Frontegg AdminPortal to 6.101.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.100.0",
+    "@frontegg/js": "6.101.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.99.0",
+    "@frontegg/js": "6.100.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.100.0",
+    "@frontegg/js": "6.101.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.99.0",
+    "@frontegg/js": "6.100.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,18 +1357,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.100.0":
-  version "6.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.100.0.tgz#d0c9d66350556af75300796cde4e274aefb19781"
-  integrity sha512-2BSLsO89BHUkyIgxn3j4jR8h1mnPH/z8unY5CaqVl/uIK+ZSEo70Nw2Sqh2diRZ7KzO7lhntpaCtI3nFaZSdUQ==
+"@frontegg/js@6.101.0":
+  version "6.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.101.0.tgz#591bc26a0777b859f63950bdf7759b7ae6edd565"
+  integrity sha512-maWcG4MdvafUgtpp9Q9MqBbVQwtToKq9IDucXhV3kiKcdrUQOW0S811sS04dUNBmhL4iby+4W2HAiv/bMjRsxg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.100.0"
+    "@frontegg/types" "6.101.0"
 
-"@frontegg/redux-store@6.100.0":
-  version "6.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.100.0.tgz#00c1b47c7fe24b7d90b8179e1b7caa19f369773b"
-  integrity sha512-RVX8hQT2JccEP7HTPfuJBZODMv/ZN9l0kJJXX4ySPbFbnauYNFXe96cv6WSqYPOP5+gPTKH93wBIJ5K4F5lMjQ==
+"@frontegg/redux-store@6.101.0":
+  version "6.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.101.0.tgz#1dc51053555c3e23d8eeaa892ce089b5e21a1338"
+  integrity sha512-50wgknSmyuP5UyvEpoEGh+9Xufld0SjsuURI4NnQu+QVzlC+2XBju07eHcap8E8wa0Zfil2Ve1cH3kYvSGkVzQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.110"
@@ -1383,13 +1383,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.100.0":
-  version "6.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.100.0.tgz#b63a9bbda98494b20e0112ad1022dece39591da2"
-  integrity sha512-VMJAIVKFX1xMw/6obw0/4VjY5oUONVTDqQXdI/UqoHZ/fVNqbeL1RfYI7X5y4kxofhdAhlAtDqdvyeWvD5n0zw==
+"@frontegg/types@6.101.0":
+  version "6.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.101.0.tgz#d74b23f76087beba1d29bbc55cc177f46ce5e2f1"
+  integrity sha512-qOwqt2qGnxVeXtw02HY5oG6UuJH2qfrZN3k549C+f8p35aKIRbgv0iWXKy/gDJaPzXUnEXLXgOUbMJ8aQjpwkw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.100.0"
+    "@frontegg/redux-store" "6.101.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,39 +1357,39 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.99.0":
-  version "6.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.99.0.tgz#dd703d7b1264ce2a289e482fdc52e5eaf6326db8"
-  integrity sha512-ZXEoGhzEnUMPKCszH1p4sEOiAc8ZOMqNFx8YFQaQroExoFTORgKqvWTpVLmzWrdWmNTj6KnTOK0c3lKwtbXv2w==
+"@frontegg/js@6.100.0":
+  version "6.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.100.0.tgz#d0c9d66350556af75300796cde4e274aefb19781"
+  integrity sha512-2BSLsO89BHUkyIgxn3j4jR8h1mnPH/z8unY5CaqVl/uIK+ZSEo70Nw2Sqh2diRZ7KzO7lhntpaCtI3nFaZSdUQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.99.0"
+    "@frontegg/types" "6.100.0"
 
-"@frontegg/redux-store@6.99.0":
-  version "6.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.99.0.tgz#c661f86d21fa1006c1eb83b7cd9b4ee42a763d4c"
-  integrity sha512-mKwKDfUuXjdFVjBQ/F84HrUX2JLEEF0qxL6xQUUxyYUqasxECY4TZZtkRu7/EeWavlKZWthT7TIdgFTTyigCDg==
+"@frontegg/redux-store@6.100.0":
+  version "6.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.100.0.tgz#00c1b47c7fe24b7d90b8179e1b7caa19f369773b"
+  integrity sha512-RVX8hQT2JccEP7HTPfuJBZODMv/ZN9l0kJJXX4ySPbFbnauYNFXe96cv6WSqYPOP5+gPTKH93wBIJ5K4F5lMjQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.109"
+    "@frontegg/rest-api" "^3.0.110"
     "@reduxjs/toolkit" "1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.109":
-  version "3.0.109"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.109.tgz#ee7794d28653b06ba26569271647f5ab9bbe8805"
-  integrity sha512-VCwpyMjPB+I+NLwMXXB8+kFxHRdTVyTzt9BLLcd4EGR4DjCds+0JaStE5vl0FY+utOJUHjRS+IXTD63k4Qm61w==
+"@frontegg/rest-api@^3.0.110":
+  version "3.0.111"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.111.tgz#a2a337b19812a4fb3c1e7075afb393d9920d027b"
+  integrity sha512-GHKm/q/mLNl5cTJDmLk+SNPdLkQ6CrffUdgfH7FWqyVPmgv/ZJVXMao0xcqxTK4qVv3yBLvaUGspz94/VaUbBw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.99.0":
-  version "6.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.99.0.tgz#117c42e0ca06be460faaf98afb01b25bd8755d2b"
-  integrity sha512-CTEVAnjoxOIRC0hJFbclGO9mro8KejQHBvzllsthKh/lNpc/7A+6w9GkC1dyrWBoXKK4LYYelVo1IESlV+zk9Q==
+"@frontegg/types@6.100.0":
+  version "6.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.100.0.tgz#b63a9bbda98494b20e0112ad1022dece39591da2"
+  integrity sha512-VMJAIVKFX1xMw/6obw0/4VjY5oUONVTDqQXdI/UqoHZ/fVNqbeL1RfYI7X5y4kxofhdAhlAtDqdvyeWvD5n0zw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.99.0"
+    "@frontegg/redux-store" "6.100.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-11722 - fix hosted login with hash [PLEASE DON'T MERGE YET]
- FR-11611 - login per tenant self service small fixes

- FR-11881 - restore search params after closing the admin portal
- FR-11878 - QA fixes for login per tenant self service
- FR-11887 - Entitlements SDK - Load entitlements list & make the data accessible for the wrappers
- FR-11152 - cyprus phone area code 2 fa screen
- FR-11658 - merge 6.99.x
- FR-11652 - Add option to upload metadata file instead of metadata url