### PR TITLE
FR-12043 - allow user to fetch entitlements by keys

### DIFF
--- a/projects/frontegg-app/src/lib/frontegg-app.service.ts
+++ b/projects/frontegg-app/src/lib/frontegg-app.service.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject, Observable, Subscription, PartialObserver } from 'rxjs
 import { FronteggLoadGuard } from './guards/frontegg-load.guard';
 import { ContextHolder, RedirectOptions, FronteggFrameworks } from '@frontegg/rest-api';
 import { FronteggComponent } from './frontegg.component';
-import { isAuthRoute } from '@frontegg/redux-store';
+import { isAuthRoute, EntitlementsState } from '@frontegg/redux-store';
 import sdkVersion from '../sdkVersion';
 
 export class FronteggAppOptionsClass implements FronteggAppOptions {
@@ -29,7 +29,7 @@ export class FronteggAppService {
     isLoading: true,
     isAuthenticated: false,
   } as FronteggState['auth']);
-  private entitlementsStateSubject = new BehaviorSubject<any>(null);
+  private entitlementsStateSubject = new BehaviorSubject<EntitlementsState['entitlements']>(undefined);
   private auditsStateSubject = new BehaviorSubject<FronteggState['audits']>({} as FronteggState['audits']);
   private connectivityStateSubject = new BehaviorSubject<FronteggState['connectivity']>({} as FronteggState['connectivity']);
   private subscriptionsStateSubject = new BehaviorSubject<FronteggState['subscriptions']>({} as FronteggState['subscriptions']);
@@ -85,7 +85,7 @@ export class FronteggAppService {
 
     entitlementsResultSubscription.unsubscribe = ()=>{
       originalUnsubscribe();
-      stateSubscription.unsubscribe()
+      stateSubscription.unsubscribe();
     };
 
     return entitlementsResultSubscription;

--- a/projects/frontegg-app/src/lib/frontegg-app.service.ts
+++ b/projects/frontegg-app/src/lib/frontegg-app.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, NgZone } from '@angular/core';
 import { Route, Router } from '@angular/router';
 import { FronteggApp, initialize } from '@frontegg/js';
 import { AuthPageRoutes, FronteggState } from '@frontegg/redux-store';
-import { FronteggAppOptions, FronteggCheckoutDialogOptions } from '@frontegg/types';
+import { FronteggAppOptions, FronteggCheckoutDialogOptions, Entitlements } from '@frontegg/types';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { FronteggLoadGuard } from './guards/frontegg-load.guard';
 import { ContextHolder, RedirectOptions, FronteggFrameworks } from '@frontegg/rest-api';
@@ -29,6 +29,7 @@ export class FronteggAppService {
     isLoading: true,
     isAuthenticated: false,
   } as FronteggState['auth']);
+  private entitlementsStateSubject = new BehaviorSubject<any>(null);
   private auditsStateSubject = new BehaviorSubject<FronteggState['audits']>({} as FronteggState['audits']);
   private connectivityStateSubject = new BehaviorSubject<FronteggState['connectivity']>({} as FronteggState['connectivity']);
   private subscriptionsStateSubject = new BehaviorSubject<FronteggState['subscriptions']>({} as FronteggState['subscriptions']);
@@ -63,6 +64,9 @@ export class FronteggAppService {
     return this.isLoadingSubject.asObservable();
   };
 
+  get entitlementsState$(): Observable<any> {
+    return this.entitlementsStateSubject.asObservable();
+  };
 
   get isAuthenticated$(): Observable<boolean> {
     return this.isAuthenticatedSubject.asObservable();
@@ -139,6 +143,7 @@ export class FronteggAppService {
 
     this.stateSubject.next(fronteggStore);
     this.authStateSubject.next(fronteggStore.auth);
+    this.entitlementsStateSubject.next(fronteggStore.auth.entitlementsState?.entitlements || null);
     this.auditsStateSubject.next(fronteggStore.audits);
     this.connectivityStateSubject.next(fronteggStore.connectivity);
     this.subscriptionsStateSubject.next(fronteggStore.subscriptions);
@@ -177,5 +182,13 @@ export class FronteggAppService {
   // Open checkout dialog
   public hideCheckoutDialog(): void {
     this.fronteggApp?.hideCheckoutDialog();
+  }
+
+  /**
+    @param keys The requested entitlement keys
+    @returns Entitlements contain true/false for every key (state of is key entitled)
+  */
+  public getEntitlements(keys: string[]): Entitlements {
+    return this.fronteggApp.getEntitlements(keys);
   }
 }


### PR DESCRIPTION
Disclaimer:
We should test somehow the refresh token and switch tenant.

User component code example:

**Component ts file:**
```ts
export class AppComponent implements OnInit, OnDestroy {
  isLoading = true;
  loadingSubscription: Subscription;
  entitlementsSubscription: Subscription;
  isFeature1Ent: boolean | undefined;
  isFeature2Ent: boolean | undefined;

  constructor(private fronteggAppService: FronteggAppService) {
    this.entitlementsSubscription = this.fronteggAppService.entitlements$(['feature-1', 'feature-2'], {
      next: (
        [{ isEntitled: isFeature1Ent }, { isEntitled: isFeature2Ent }]: Entitlements
      ) => {
        this.isFeature1Ent = isFeature1Ent;
        this.isFeature2Ent = isFeature2Ent;
      }
    });
  }

  ngOnDestroy(): void {
    this.loadingSubscription.unsubscribe();
    this.entitlementsSubscription.unsubscribe();
  }
}
```

Component html file:
```html
<div *ngIf="!isLoading">
    <router-outlet></router-outlet>
    <div *authorizedContent="['Admin']">Authorized content section for Admin's (example)</div>
    <div>Feature 1: {{isFeature1Ent ? 'on' : 'off'}}</div>
    <div>Feature 2: {{isFeature2Ent ? 'on' : 'off'}}</div>
</div>
```