### PR TITLE
Update Frontegg AdminPortal to 6.107.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.106.0",
+    "@frontegg/js": "6.107.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.105.0",
+    "@frontegg/js": "6.106.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.104.0",
+    "@frontegg/js": "6.105.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.106.0",
+    "@frontegg/js": "6.107.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.104.0",
+    "@frontegg/js": "6.105.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.105.0",
+    "@frontegg/js": "6.106.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,18 +1357,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.106.0":
-  version "6.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.106.0.tgz#3b7673de5f20bebe4e67a6c84af82ae476f03da5"
-  integrity sha512-cvT2PjmDBgT7RcbkqsWqPgSo3Gw80ly3zMMWAVpel/l+uRI/iY+uhJp0UWCRaK0n5N0JzmkpzkImW0dW8hAklA==
+"@frontegg/js@6.107.0":
+  version "6.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.107.0.tgz#44048f31e5817ac943549003f2b1c745e98de985"
+  integrity sha512-o8ORph98xEPTlaDDcwOMyzskuz3EkO7HDpthWPy4iUvQVgJAfn4ZNji28F86hMsj2Ovs56VjcgNm73qTq5Gvkw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.106.0"
+    "@frontegg/types" "6.107.0"
 
-"@frontegg/redux-store@6.106.0":
-  version "6.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.106.0.tgz#7dd96a0fff0498808a3fdb1b26c26171ebe38396"
-  integrity sha512-sm8TfYGtCyz1MSlr+c3Pr5Gm3AAQNSDfnbA2GbUC8NVcyBt0xOt/iH9AAtJA6w5N7GuMAFSIIlrYdsNVviZ95A==
+"@frontegg/redux-store@6.107.0":
+  version "6.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.107.0.tgz#62ba8ce731967efb42e7acd696e935ca9a931395"
+  integrity sha512-5JNzaIjh4t3eACmT3aIYC8aG8YvvZvfIWo5KuyBpSRIHlAFimJy4onmR74uQj58YqSFqbnLOePjyGzbRVRqSmw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.118"
@@ -1383,13 +1383,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.106.0":
-  version "6.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.106.0.tgz#a1c4c5decef1c7351f2a869973dd1b96db21b26c"
-  integrity sha512-SrljuuagvKj6x1dsE2OuPNB95UFFztJkh6n4cggPRtclANBzQ/TAvZzJugs1NSoY5OEzlu2iqL4j8modEwDD2g==
+"@frontegg/types@6.107.0":
+  version "6.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.107.0.tgz#0021d48d70001a6240e2f7a2cfdf6e9acc3afe78"
+  integrity sha512-vD2DnmRq+7S/AkBICIpeieCEQu7CCGFylMbEO+bMUoWswe4vHlWEP9q6pPRWbf04uAQmtdk7ZUrYwKJZCDBJaA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.106.0"
+    "@frontegg/redux-store" "6.107.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,18 +1357,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.105.0":
-  version "6.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.105.0.tgz#7cbc234a5fb5c930719171392299a209492d331c"
-  integrity sha512-H/eayzCiU0UygEfCRaCprfYd7TXHpjqt4ehhUZAymJSTN+HPZh3bIMousG/qaxSWq2eYKBt6kRbYshJUCUyPiQ==
+"@frontegg/js@6.106.0":
+  version "6.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.106.0.tgz#3b7673de5f20bebe4e67a6c84af82ae476f03da5"
+  integrity sha512-cvT2PjmDBgT7RcbkqsWqPgSo3Gw80ly3zMMWAVpel/l+uRI/iY+uhJp0UWCRaK0n5N0JzmkpzkImW0dW8hAklA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.105.0"
+    "@frontegg/types" "6.106.0"
 
-"@frontegg/redux-store@6.105.0":
-  version "6.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.105.0.tgz#8daed7eeb5f32cf54b954e1095e05885269b96f6"
-  integrity sha512-meeYw6kox+bFX4OXH9wYqPYAXGbZYEB6YFbLz/0M0QdVX41SWIy5ymTaXFn6+1RRm6Cm/ghHlibFK3DMg8LFrQ==
+"@frontegg/redux-store@6.106.0":
+  version "6.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.106.0.tgz#7dd96a0fff0498808a3fdb1b26c26171ebe38396"
+  integrity sha512-sm8TfYGtCyz1MSlr+c3Pr5Gm3AAQNSDfnbA2GbUC8NVcyBt0xOt/iH9AAtJA6w5N7GuMAFSIIlrYdsNVviZ95A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.118"
@@ -1383,13 +1383,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.105.0":
-  version "6.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.105.0.tgz#200ff3bd8439eb515e8e12767c9968048c614b72"
-  integrity sha512-uC3ZOKUBNlXYC6E3qJtb9UYxnsZvKdkPIyrhR/kl4txCAseLE+QImiCuWe/ybLC4FWVmgfXvZWKVTatpfLzpWA==
+"@frontegg/types@6.106.0":
+  version "6.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.106.0.tgz#a1c4c5decef1c7351f2a869973dd1b96db21b26c"
+  integrity sha512-SrljuuagvKj6x1dsE2OuPNB95UFFztJkh6n4cggPRtclANBzQ/TAvZzJugs1NSoY5OEzlu2iqL4j8modEwDD2g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.105.0"
+    "@frontegg/redux-store" "6.106.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,39 +1357,39 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.104.0":
-  version "6.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.104.0.tgz#3f0064101cc3a82e53d8ee2c7ae5750f9cc56b0e"
-  integrity sha512-NlPiccxgx7i80+hWU73jR5l8Lx4PTH6LdsavlxwLgqqPY1JyhkCZH88aY+T6rmwsPnc26Tf9eqnBufUdtE3+PA==
+"@frontegg/js@6.105.0":
+  version "6.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.105.0.tgz#7cbc234a5fb5c930719171392299a209492d331c"
+  integrity sha512-H/eayzCiU0UygEfCRaCprfYd7TXHpjqt4ehhUZAymJSTN+HPZh3bIMousG/qaxSWq2eYKBt6kRbYshJUCUyPiQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.104.0"
+    "@frontegg/types" "6.105.0"
 
-"@frontegg/redux-store@6.104.0":
-  version "6.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.104.0.tgz#cb1c50893d2f96119a74318fbc5be3a3669bb955"
-  integrity sha512-n98A11HT/NWRYiTtp9Dv2JAaq5BxXARudgg7OOkVf0iFkRNy1AWiv87+Rzv8QjdroeW6ARkW6COn6Mno48FRvA==
+"@frontegg/redux-store@6.105.0":
+  version "6.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.105.0.tgz#8daed7eeb5f32cf54b954e1095e05885269b96f6"
+  integrity sha512-meeYw6kox+bFX4OXH9wYqPYAXGbZYEB6YFbLz/0M0QdVX41SWIy5ymTaXFn6+1RRm6Cm/ghHlibFK3DMg8LFrQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.116"
+    "@frontegg/rest-api" "^3.0.118"
     "@reduxjs/toolkit" "1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.116":
-  version "3.0.116"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.116.tgz#5d439335b12f9b5671705c54793efa4f9771a0a4"
-  integrity sha512-QHS18raujGblaJQ5QuuEJijDblUwFdiSc4aeFDN+oN2V53v2N1TLBmuJPqo0boHWfzlkTKUyh520Nh+gmakEgg==
+"@frontegg/rest-api@^3.0.118":
+  version "3.0.118"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.118.tgz#a59238d587811d9e49ad924208f4ae785b293316"
+  integrity sha512-NKY3vcFSzf0B9SEkkJV8Uv2rDA9ML8g5wOqw+/p9QtLL6Vsc7LErn650Gf4Ib/LvDqncIYbGSvsjnnIJ5teevg==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.104.0":
-  version "6.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.104.0.tgz#bc273206784a033c91ae189461c5e3ef94201afb"
-  integrity sha512-6zluonf98EqKQnPPcM3FEMeMwvrq4yhFvI5y7EUjqsuU/S63AShcrldEDmUA3+E3o3ovUj5og28GRte9Cjyq9w==
+"@frontegg/types@6.105.0":
+  version "6.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.105.0.tgz#200ff3bd8439eb515e8e12767c9968048c614b72"
+  integrity sha512-uC3ZOKUBNlXYC6E3qJtb9UYxnsZvKdkPIyrhR/kl4txCAseLE+QImiCuWe/ybLC4FWVmgfXvZWKVTatpfLzpWA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.104.0"
+    "@frontegg/redux-store" "6.105.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-12257 - msp give access permission fix
- FR-12257 - MSP bugfix, improvements
- FR-12236 - fix new sso guide dark theme

- FR-12159 - msp bug fix
- FR-12221 - support both null and props for custom components

- FR-12159 - msp all accounts bugfix
- FR-12115 - sso guides crash unless acs url is specified
- FR-12225 - fix appearance saml and OIDC according to vendor configuration
- FR-12221 - support props and frontegg hooks in custom components
- FR-12146 - bugfix msp all accounts
- FR-12201 - dont send redirect uri on OIDC callback
- FR-12187 - FR-12188 - fix login per tenant embedded with sub domain logout route
- FR-11842 - navigation metadata msp
- FR-11887 - load ff before entitlements and prevent load for logged out users
- FR-11842 - msp single account view
- FR-11971 - implement breached password ui