### PR TITLE
Update Frontegg AdminPortal to 6.123.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.121.0",
+    "@frontegg/js": "6.122.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.120.0",
+    "@frontegg/js": "6.121.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~12.0.5",
     "@angular/platform-browser-dynamic": "~12.0.5",
     "@angular/router": "~12.0.5",
-    "@frontegg/js": "6.122.0",
+    "@frontegg/js": "6.123.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.122.0",
+    "@frontegg/js": "6.123.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.121.0",
+    "@frontegg/js": "6.122.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.120.0",
+    "@frontegg/js": "6.121.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,18 +1357,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.122.0":
-  version "6.122.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.122.0.tgz#5a587d9bee5330ee76ee82608eae2ebcfddc9f27"
-  integrity sha512-l+4tvKElEeqAIcZYcDsVI+2+SvTJ9Re4W7Y/sm+yNPagAmBjXe+vPgqO3H+RE1kugkGN0sdgE0wrebl0oYOubA==
+"@frontegg/js@6.123.0":
+  version "6.123.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.123.0.tgz#c5fdeb901d5ba7e0aefbef165330bfbb7c969c43"
+  integrity sha512-bRwyulwPrg8K123CjuXbsSTqimRoAZ9xD34DIOqJuC58BGHFn0qALdNG1+5aeU1cI7sVUT5lM+4cq0+hMEWBwQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.122.0"
+    "@frontegg/types" "6.123.0"
 
-"@frontegg/redux-store@6.122.0":
-  version "6.122.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.122.0.tgz#4a042e771d7beb3ef68973153c3d1e280987fa20"
-  integrity sha512-uxJ+D3YcrK+CWcIKAkOJHeDJpiOsQMs7Yn1E2X7T2RcnkILSyDnSFIHCXI9s6y0qhBs2/gFJGf5UUERhifEXsA==
+"@frontegg/redux-store@6.123.0":
+  version "6.123.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.123.0.tgz#d5030744cd6887867511fa6045fbe48c6c455b44"
+  integrity sha512-WZgRhXmbOgifnC2pcUevVy7q8CPRmrJXGxK52GDdNzK1cxbqIIYEY9wvuS726Lesp6td55coD6Aecs4+8uT9iA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.1.5"
@@ -1384,13 +1384,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.122.0":
-  version "6.122.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.122.0.tgz#0434dce51f476347e48dba1ea26f962de7f47553"
-  integrity sha512-J3KpZkaZ/O4+rPyfqs87pRbL5+sfkZpuenGSfZ5WZ9kVeMN2sETVtpqvWWvCq2flmBxg9/UsIdfyGkrivwnefg==
+"@frontegg/types@6.123.0":
+  version "6.123.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.123.0.tgz#b9368fa71db783801ca197ef6132d6595132c58b"
+  integrity sha512-/HWSjCsgegwGkjNzCMxkEvV9OjwqGADpkav7ujBklclRWa8MpH2t3E/QKWdNsu3WoJI4mzSfYbE1CGDhnieGyw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.122.0"
+    "@frontegg/redux-store" "6.123.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,40 +1357,40 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.120.0":
-  version "6.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.120.0.tgz#b39a4dca5b8e53d4ffb1933445a4034f966e02a8"
-  integrity sha512-Z56dnDvu7BW6A+KsZVDexPrxDZHqWRmSRol48y7iAFuxwy/CvMMIvkPyvzvot66LB7r6LV2rOArCpm26QHkP5Q==
+"@frontegg/js@6.121.0":
+  version "6.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.121.0.tgz#3428420d44efb573fed3297e8f1c51ded1dc8b25"
+  integrity sha512-dEKex48tiMtR6bi4c7fhgHTM2F11XJopqdoHcIb1VKlC/eSZJxwum+w66W5+PF+CpESM3JtzRac+pqi3TW3KdQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.120.0"
+    "@frontegg/types" "6.121.0"
 
-"@frontegg/redux-store@6.120.0":
-  version "6.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.120.0.tgz#cb9498bee01f2c2844de6f6a4768431727fd23cb"
-  integrity sha512-lMTbPddt/vMs0httbZsbm1I3sBSF7Vk8l2Iz66GkO+9EQOuy4wg5JOhEubwBo18jzt2WqKjSBu/v8MSz1bTRrw==
+"@frontegg/redux-store@6.121.0":
+  version "6.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.121.0.tgz#32b7363d6e61e0bdab74b1a61d357f5f0f4b80cd"
+  integrity sha512-Wq9SrqWZynKM8fzg2QVX6tYQRlqnTQdi0JuQZ953GFr+ti7kR0aX6V//vL5g7vnVf9MZp3Ds0Yna5i42FdXWfw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.140"
+    "@frontegg/rest-api" "3.1.5"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.140":
-  version "3.0.140"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.140.tgz#2bdca4b7f3062c7d05c07d8b92f0600e52368c39"
-  integrity sha512-HVxlJlMrTPZo7BYkaaKx6mrat/LIVgtduU6qWwgzyyrIrElpaM+GI9bqwod/EjrDcJ9qmqf5dvTbncFV4Bm63Q==
+"@frontegg/rest-api@3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.5.tgz#8938923659540a34b66f19a1ac1f2717d310d3ea"
+  integrity sha512-4laNfirbpDxIlXsBKad8InaG0bd8LHn3KP8SVkmSyKzsKPve6lOv1yTYMQdFNCamxP9cw8NDMSoEUrKd9UlsTw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.120.0":
-  version "6.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.120.0.tgz#a3c60ceb80c17abf64960aece93638920fc90816"
-  integrity sha512-aLbJTaVEEAsB4tUvb0mz48fGYxkWS0TGW5tWo+DBZuub+0AlAuVqjfEPd2kr0vDtrJaJBjzz37PxNNtglGhNrg==
+"@frontegg/types@6.121.0":
+  version "6.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.121.0.tgz#240adb82916fc7f111c289b1dcd838e31ffc82c3"
+  integrity sha512-oeCt6KUVZ2Q/0qFEBOOL/hrnk/F/pFI1sgYysdGZozvb9n4npEk2S61/FPOnz7tOZdQ48NjtXtPTAfUpFiKq9A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.120.0"
+    "@frontegg/redux-store" "6.121.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,18 +1357,18 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
-"@frontegg/js@6.121.0":
-  version "6.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.121.0.tgz#3428420d44efb573fed3297e8f1c51ded1dc8b25"
-  integrity sha512-dEKex48tiMtR6bi4c7fhgHTM2F11XJopqdoHcIb1VKlC/eSZJxwum+w66W5+PF+CpESM3JtzRac+pqi3TW3KdQ==
+"@frontegg/js@6.122.0":
+  version "6.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.122.0.tgz#5a587d9bee5330ee76ee82608eae2ebcfddc9f27"
+  integrity sha512-l+4tvKElEeqAIcZYcDsVI+2+SvTJ9Re4W7Y/sm+yNPagAmBjXe+vPgqO3H+RE1kugkGN0sdgE0wrebl0oYOubA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.121.0"
+    "@frontegg/types" "6.122.0"
 
-"@frontegg/redux-store@6.121.0":
-  version "6.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.121.0.tgz#32b7363d6e61e0bdab74b1a61d357f5f0f4b80cd"
-  integrity sha512-Wq9SrqWZynKM8fzg2QVX6tYQRlqnTQdi0JuQZ953GFr+ti7kR0aX6V//vL5g7vnVf9MZp3Ds0Yna5i42FdXWfw==
+"@frontegg/redux-store@6.122.0":
+  version "6.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.122.0.tgz#4a042e771d7beb3ef68973153c3d1e280987fa20"
+  integrity sha512-uxJ+D3YcrK+CWcIKAkOJHeDJpiOsQMs7Yn1E2X7T2RcnkILSyDnSFIHCXI9s6y0qhBs2/gFJGf5UUERhifEXsA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.1.5"
@@ -1384,13 +1384,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.121.0":
-  version "6.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.121.0.tgz#240adb82916fc7f111c289b1dcd838e31ffc82c3"
-  integrity sha512-oeCt6KUVZ2Q/0qFEBOOL/hrnk/F/pFI1sgYysdGZozvb9n4npEk2S61/FPOnz7tOZdQ48NjtXtPTAfUpFiKq9A==
+"@frontegg/types@6.122.0":
+  version "6.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.122.0.tgz#0434dce51f476347e48dba1ea26f962de7f47553"
+  integrity sha512-J3KpZkaZ/O4+rPyfqs87pRbL5+sfkZpuenGSfZ5WZ9kVeMN2sETVtpqvWWvCq2flmBxg9/UsIdfyGkrivwnefg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.121.0"
+    "@frontegg/redux-store" "6.122.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-12696 - Entitlements redesign
- FR-12537 - recomendations component
- FR-12675 - add security center context holder and mappers for recommendations&#x2F;insights


- FR-12703 - Make sure to update correctly the change log in wrappers


- FR-12688 - Make Admin box compatible with the updated type of IUserProfile
- FR-12649 - Added a skeleton for the new security center page
