### PR TITLE
FR-12555 - support-release-ivy-engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --configuration production",
     "dev": "ng build --watch",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
releasing version with ivy engine fails

found out that above angular 12 adding `--configuration productio`n to build should fix it [link](https://stackoverflow.com/questions/60234048/angular-9-library-publish-error-trying-to-publish-a-package-that-has-been-compi)