### PR TITLE
Update Frontegg AdminPortal to 6.138.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.137.0",
+    "@frontegg/js": "6.138.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.137.0",
+    "@frontegg/js": "6.138.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,40 +1558,40 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@frontegg/js@6.137.0":
-  version "6.137.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.137.0.tgz#5c5e0d659099879d0dc1efdbdbcf1fbfd538c437"
-  integrity sha512-3RmyCXmZew36hI1jEQp8rCaZako+e1kd/RANruQ9OTTO8PTQfYuan99fC1fXw+vOu7PINlKvMdC15/sIWJTGww==
+"@frontegg/js@6.138.0":
+  version "6.138.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.138.0.tgz#b9eb65dcf7aef845b4093f8a65e1e66dd9a9f794"
+  integrity sha512-oP/9jw2+s3RnnkjgSVG30CCSWTlPo+WqHsAVxsEywdkcrcMZJB+B4iBmxjGHZwB1yn4H3exlzfMZ2/7kykhGag==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.137.0"
+    "@frontegg/types" "6.138.0"
 
-"@frontegg/redux-store@6.137.0":
-  version "6.137.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.137.0.tgz#3d096fd07fb35e4e49b20039309ddf565e0b11fb"
-  integrity sha512-cn1gmA2hRS6RwgOMly/xqvrPsFcI0B/EZoCAYVt9EhRx8gtgiJpv7sTHEtt6McElVSHp7DzR2U5sr4Fp3uRX0Q==
+"@frontegg/redux-store@6.138.0":
+  version "6.138.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.138.0.tgz#5db09f6005924fd05434446a912c306714253dab"
+  integrity sha512-aacmQNHfFAfWyhasLbTkGsQ9hMX+eI+rA7uE9AAOcQH/XXDY2HkqW9A6OY/X/tDf4mjfnIuBQyVWQQG6MlUanw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.1.17"
+    "@frontegg/rest-api" "3.1.18"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.1.17":
-  version "3.1.17"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.17.tgz#0324ae6c647f27066bdc2b75c96530bc95afa5b6"
-  integrity sha512-49EqP7QVE7+uTnXnjnSv6BhVg35mboFTHLoQl4Pjhux2bST/rrJB/nXLAXbXBJQ41ndyfgSnpNpl7LmQWvFcgw==
+"@frontegg/rest-api@3.1.18":
+  version "3.1.18"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.18.tgz#9805ea2ea158f55d762c6b21ed0353e4f29644ca"
+  integrity sha512-7ZJ1LDFNr7wgqWGnmh9LTz2UohoR/r2KIo1F/eROL6O+sOgYzWesr+Xcerw276btCYsMKsXAqC21ihH+BlKN5Q==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.137.0":
-  version "6.137.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.137.0.tgz#9f95268e143c8b624936ffc3ec27b7539fd44e5e"
-  integrity sha512-vGdsCsik8s6E1r/oUhjP5ejLNw1vgWuEzknfPghg4DkioQeda/UDIN3Yycuzi+5s6lEfsv5xcAcaCmaARnEIuQ==
+"@frontegg/types@6.138.0":
+  version "6.138.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.138.0.tgz#99cf5a37fb0575de23dd3924604999b6275d7590"
+  integrity sha512-5Aeab7w+X+LHDUut8tH4hZPwzgnNe4yuVNI7vDwOgDCPquPWIdYR10qC70y+YijR7L5t4lv2+/JwUQieNNpfxg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.137.0"
+    "@frontegg/redux-store" "6.138.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- Releasing the new Security Center Page, which will replace the current Security Page. Currently exposed on Early Access with limited availability by a feature flag.
