### PR TITLE
FR-13820 - Rule based entitlements preparations

### DIFF
--- a/projects/frontegg-app/src/lib/frontegg-entitlements.service.ts
+++ b/projects/frontegg-app/src/lib/frontegg-entitlements.service.ts
@@ -1,8 +1,7 @@
 import { Subscription, PartialObserver, BehaviorSubject } from 'rxjs';
-import { User, AuthState } from '@frontegg/redux-store';
+import { AuthState } from '@frontegg/redux-store';
 import { Injectable } from '@angular/core';
 import { Entitlement, LoadEntitlementsCallback, EntitledToOptions } from '@frontegg/types';
-import { UserEntitlementsResponse } from '@frontegg/rest-api';
 
 import {
   FronteggState,

--- a/projects/frontegg-app/src/lib/frontegg-entitlements.service.ts
+++ b/projects/frontegg-app/src/lib/frontegg-entitlements.service.ts
@@ -2,6 +2,7 @@ import { Subscription, PartialObserver, BehaviorSubject } from 'rxjs';
 import { User, AuthState } from '@frontegg/redux-store';
 import { Injectable } from '@angular/core';
 import { Entitlement, LoadEntitlementsCallback, EntitledToOptions } from '@frontegg/types';
+import { UserEntitlementsResponse } from '@frontegg/rest-api';
 
 import {
   FronteggState,
@@ -21,7 +22,7 @@ import { FronteggAppService } from './frontegg-app.service';
   providedIn: 'root',
 })
 export class FronteggEntitlementsService {
-  private entitlementsStateSubject = new BehaviorSubject<User['entitlements']>(undefined);
+  private entitlementsStateSubject = new BehaviorSubject<any>(undefined);
   
   constructor(private fronteggAppService: FronteggAppService) {
     const state = this.fronteggAppService.fronteggApp.store.getState() as FronteggState;
@@ -40,7 +41,7 @@ export class FronteggEntitlementsService {
    * @param authState
    */
   private updateEntitlementsStateIfNeeded(authState: AuthState): void {
-    const entitlementsState = authState.user?.entitlements;
+    const entitlementsState = authState.user?.entitlements as any;
     if (this.entitlementsStateSubject.value === entitlementsState) {
       return;
     }
@@ -56,7 +57,7 @@ export class FronteggEntitlementsService {
    * @returns a subscription to be able to unsubscribe
    */
   private getEntitlementsManipulatorSubscription<Result>(
-    dataManipulator: (entitlements: User['entitlements']) => Result, 
+    dataManipulator: (entitlements: any) => Result, 
     observer: PartialObserver<Result>
   ): Subscription {
     // used for computing the entitlements result because we don't return the state itself, but a calculated one


### PR DESCRIPTION
preparation for upgrading rest-api to prevent admin box frameworks testing failures
when upgrading rest-api to entitlements v2 the types are different. 
Then when we want to upgrade admin box Angular tests fail because of mismatch of store types.
To support it this PR change types to any. We will fix it at the end.