### PR TITLE
Update Frontegg AdminPortal to 6.157.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.155.0",
+    "@frontegg/js": "6.156.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.156.0",
+    "@frontegg/js": "6.157.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.155.0",
+    "@frontegg/js": "6.156.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.156.0",
+    "@frontegg/js": "6.157.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,18 +1563,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.155.0":
-  version "6.155.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.155.0.tgz#2bdb59784a4c022101c4dc206788527ae3552f1d"
-  integrity sha512-G0qtkooOBn2uMmJfCT+U3yYpWs1pbF1ftHn0XwzJAF+i4JVxgYhcjiE7u4VaDVCIsz6rszGxiKqTyWMrlLOxFg==
+"@frontegg/js@6.156.0":
+  version "6.156.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.156.0.tgz#5f2dfd8a1d991e2832103abd2d5a4b85e5b10ac3"
+  integrity sha512-+kVWL3IHajw23fZ5dudwHuPGdmyvO+jiuE0SqWBADiBpM+OHcU4tI6dCAIdq+PoJjfhrvhngUMoubfJHWZ5ghQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.155.0"
+    "@frontegg/types" "6.156.0"
 
-"@frontegg/redux-store@6.155.0":
-  version "6.155.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.155.0.tgz#d2911ede63bb5927a485a0c78861e249b890a14d"
-  integrity sha512-C9hHCBTSzCLyC89kw/gNwzwUvR51JLu7qqUzoamuWS3S3bpkMXZVF/sedGTrpAkVkwXS1jaWpzi7VNsMOREaYQ==
+"@frontegg/redux-store@6.156.0":
+  version "6.156.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.156.0.tgz#9f0941e6d38580695ca3b5baf1c73abd919b88d9"
+  integrity sha512-duwJo/zHiLo45ThRt/glNqsUYRILpCSWAhWncg0JL/Et+0abyyU5pHrmYBOipbjC4X6+K2/3DltedoRgcIAqTw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1592,13 +1592,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.155.0":
-  version "6.155.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.155.0.tgz#73d49002fbaf5ebbb732f0adfbaf81889fc76cda"
-  integrity sha512-YfS3FBJGoJ/CRdqP7HHyBPFoLsdtKQuX1QV2d+LUfROtTOCK7W8TMXK7TXqC5piN0NdZcafvA/BrfbAVVohXdA==
+"@frontegg/types@6.156.0":
+  version "6.156.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.156.0.tgz#09d8042e7f73db388b5a6f7447df42afd4bf126a"
+  integrity sha512-VsBV36ThWVIp6T79RVIJ7iiPug30fLbNCnvDeLmVqXkygRkIWJt1sGX1ViIHZI3HSTtI8mek0+RCynIdWq9Pew==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.155.0"
+    "@frontegg/redux-store" "6.156.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,18 +1563,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.156.0":
-  version "6.156.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.156.0.tgz#5f2dfd8a1d991e2832103abd2d5a4b85e5b10ac3"
-  integrity sha512-+kVWL3IHajw23fZ5dudwHuPGdmyvO+jiuE0SqWBADiBpM+OHcU4tI6dCAIdq+PoJjfhrvhngUMoubfJHWZ5ghQ==
+"@frontegg/js@6.157.0":
+  version "6.157.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.157.0.tgz#38dce095be701617d99278aed788a956c06156d1"
+  integrity sha512-INE3z81bUDoByl9weDyqGa3BTNF4Qi3L//USNUkUj36wocIoVzwm4wDHl/R0TxOe+ronkMUiRjIa2EwpA6+Bmw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.156.0"
+    "@frontegg/types" "6.157.0"
 
-"@frontegg/redux-store@6.156.0":
-  version "6.156.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.156.0.tgz#9f0941e6d38580695ca3b5baf1c73abd919b88d9"
-  integrity sha512-duwJo/zHiLo45ThRt/glNqsUYRILpCSWAhWncg0JL/Et+0abyyU5pHrmYBOipbjC4X6+K2/3DltedoRgcIAqTw==
+"@frontegg/redux-store@6.157.0":
+  version "6.157.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.157.0.tgz#4f64b94195115c3ce17b412f76ca303460a4b345"
+  integrity sha512-eV1F6R52JIqittP9sgNo8nqqkCkbgUkIaQfoH7BenNSE45fEWGBG1O0/IlQ3jMm+pVWW9h6hUx8yMVbNyRdGzg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1592,13 +1592,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.156.0":
-  version "6.156.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.156.0.tgz#09d8042e7f73db388b5a6f7447df42afd4bf126a"
-  integrity sha512-VsBV36ThWVIp6T79RVIJ7iiPug30fLbNCnvDeLmVqXkygRkIWJt1sGX1ViIHZI3HSTtI8mek0+RCynIdWq9Pew==
+"@frontegg/types@6.157.0":
+  version "6.157.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.157.0.tgz#c2c3bfdbc8720ea1e91197b5521cb3246bd59729"
+  integrity sha512-kK8+ca6DuxruYhw/XQjVRaglVLbhMfSicB8LPqvOcVIKly3OOlcdTA39bTq8/3McM/UDpv68GKlHVQjJqUfg3A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.156.0"
+    "@frontegg/redux-store" "6.157.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-13527 - Added a11y support for admin portal pages: sso, security, profile, personal tokens, users, groups, provisioning, audit logs, api tokens, webhooks, account details.