### PR TITLE
FR-14187 - support standalone components

### DIFF
--- a/projects/frontegg-app/src/lib/frontegg-app.module.ts
+++ b/projects/frontegg-app/src/lib/frontegg-app.module.ts
@@ -1,4 +1,4 @@
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FronteggAppOptions } from '@frontegg/types';
@@ -19,18 +19,20 @@ export class FronteggAppModule {
   static forRoot(config: FronteggAppOptions): ModuleWithProviders<FronteggAppModule> {
     return {
       ngModule: FronteggAppModule,
-      providers: [
-        FronteggAppService,
-        FronteggAuthGuard,
-        FronteggLoadGuard,
-        FronteggAuthService,
-        FronteggEntitlementsService,
-        FronteggSubscriptionService,
-        {
-          provide: FronteggAppOptionsClass,
-          useValue: config,
-        },
-      ],
+      providers: provideFrontegg(config)
     };
   }
 }
+
+export const provideFrontegg = (config: FronteggAppOptions): Provider[] => [
+  FronteggAppService,
+  FronteggAuthGuard,
+  FronteggLoadGuard,
+  FronteggAuthService,
+  FronteggEntitlementsService,
+  FronteggSubscriptionService,
+  {
+    provide: FronteggAppOptionsClass,
+    useValue: config,
+  }
+]

--- a/projects/frontegg-app/src/public-api.ts
+++ b/projects/frontegg-app/src/public-api.ts
@@ -2,7 +2,7 @@
  * Public API Surface of frontegg-app
  */
 
-export { FronteggAppModule } from './lib/frontegg-app.module';
+export { FronteggAppModule, provideFrontegg } from './lib/frontegg-app.module';
 export { FronteggAppService } from './lib/frontegg-app.service';
 export { FronteggComponent } from './lib/frontegg.component';
 export { FronteggAuthService } from './lib/frontegg-auth.service';


### PR DESCRIPTION
Create `provideFrontegg` function to provide all frontegg provider in the root of the application. 
using this function will look like this - 
```
// inside app.config.ts created by angular/cli 17
import { ApplicationConfig } from '@angular/core';
import { provideRouter } from '@angular/router';
import { routes } from './app.routes';
import { provideFrontegg } from '@frontegg/angular';

const fronteggConfig = {
  contextOptions: {
    baseUrl: 'https://yuvaldev.stg.frontegg.com',
  }
}

export const appConfig: ApplicationConfig = {
  providers: [
    provideRouter(routes),
    provideFrontegg(fronteggConfig),
  ],
};

```