### PR TITLE
Update Frontegg AdminPortal to 6.175.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.170.0",
+    "@frontegg/js": "6.171.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.174.0",
+    "@frontegg/js": "6.175.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.172.0",
+    "@frontegg/js": "6.173.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.169.0",
+    "@frontegg/js": "6.170.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.168.0",
+    "@frontegg/js": "6.169.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.173.0",
+    "@frontegg/js": "6.174.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "6.171.0",
+    "@frontegg/js": "6.172.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.171.0",
+    "@frontegg/js": "6.172.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.173.0",
+    "@frontegg/js": "6.174.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.174.0",
+    "@frontegg/js": "6.175.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.168.0",
+    "@frontegg/js": "6.169.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.172.0",
+    "@frontegg/js": "6.173.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.170.0",
+    "@frontegg/js": "6.171.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "6.169.0",
+    "@frontegg/js": "6.170.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,42 +1563,42 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.172.0":
-  version "6.172.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.172.0.tgz#d1aa9b550695996092fc5ea341d0bf2cfad982f5"
-  integrity sha512-ycfwXgwDZ42hxgxSXqv/PH2SppA3fY54yjODWIAxl6McczaFDdGkp6dILXgd2pnNJPvoVyVErkSaigAwD0e7Rg==
+"@frontegg/js@6.173.0":
+  version "6.173.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.173.0.tgz#85e2b8bf2c9f12e89c89bbd36e09896b6935437b"
+  integrity sha512-eMXZZQ2KFY5zplEFi+zga5uUNUaOzhsUK7ZEbG6NfbzPoHyHS+DOiLE/njaoxyiw/Acq4auCyNt2+h/NIG9dCQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.172.0"
+    "@frontegg/types" "6.173.0"
 
-"@frontegg/redux-store@6.172.0":
-  version "6.172.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.172.0.tgz#7a56835d3c4fd89d0f5db5bc946a2fa367524776"
-  integrity sha512-rER4zYd5fy8UaxY3zYX+nDcPh0OdIjirbAV+yR/3FU2BzSoMhYEFFYvZnwbUqgEF1nyZzRIMOYW/FaOfjs2OCw==
+"@frontegg/redux-store@6.173.0":
+  version "6.173.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.173.0.tgz#97daae7627e64573acdff64bb30c2e150dea8106"
+  integrity sha512-YhjovUbpkxhEmtWDZokmcXvXv9LcCfgQXBwLQeX0BAnleAZE1hoeQa5runkpQYpoHWdn33piZMhs+ZhFhFBU7w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
-    "@frontegg/rest-api" "3.1.56"
+    "@frontegg/rest-api" "3.1.57"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.1.56":
-  version "3.1.56"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.56.tgz#e03a23f48d2782257595ef0544fe9281d20be06e"
-  integrity sha512-Nu2alTWrBPEhy80v7HPRECXlbJOY80SitGh8GrA/lvf5CQ3L+HC6aSM7Cone3XaSNJt7Uopz3hJkkBUtiA08rg==
+"@frontegg/rest-api@3.1.57":
+  version "3.1.57"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.57.tgz#fa1890e7d1175ca6a31bec03bb8dd119dffe5a6f"
+  integrity sha512-n2sm4/Bh7lG2eJ6RgP4n9BUcOc9Mc4bnwr8ItmZwbNReWYieDcOX+R0ViuTOyDN5KLu0oV5I2Ii7mYnqtf8Q4A==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.172.0":
-  version "6.172.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.172.0.tgz#023fdd78f5ba6a2359516b6a8f1bbce1a7cf6f7c"
-  integrity sha512-U1F7n0BpMYoUVG/G50gct/YIBY30OvisMARCdEBXOkvXCqyL39RCUsqNM0Xle8Dw9+KA/lxpko/lugdrc13EPQ==
+"@frontegg/types@6.173.0":
+  version "6.173.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.173.0.tgz#8daab0a6cc1984ee8e596445c9c83c2d9547386c"
+  integrity sha512-ijCHSejGAAkeKWfja7ZX3qgT7OgEFXqu/gbex3sKZfx0K1K18oKI/CFsxskhJATRi/qqQj/5HZiE7Sk13u1ldQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.172.0"
+    "@frontegg/redux-store" "6.173.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,18 +1563,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.171.0":
-  version "6.171.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.171.0.tgz#5d68a925951b668565d0a09077f3e42ae3423877"
-  integrity sha512-7VYhY4qw3Dgkq8GzlTU39offTON3pLonoNtr4h7AkiIh/Lwqr/h0fSgwt1T2sZZn39s1PO752APtcGuEVTcC+g==
+"@frontegg/js@6.172.0":
+  version "6.172.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.172.0.tgz#d1aa9b550695996092fc5ea341d0bf2cfad982f5"
+  integrity sha512-ycfwXgwDZ42hxgxSXqv/PH2SppA3fY54yjODWIAxl6McczaFDdGkp6dILXgd2pnNJPvoVyVErkSaigAwD0e7Rg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.171.0"
+    "@frontegg/types" "6.172.0"
 
-"@frontegg/redux-store@6.171.0":
-  version "6.171.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.171.0.tgz#69b34a58ff3e1b5e25b9ee60e9ee7cf35677300c"
-  integrity sha512-lwkRb2L6WTNmjnUp9DzLe9KMMdKvKHW/9YIVjKdLRZke8PdF7zyBFWvolwnqqriXvIdRxa0pBAbXmRBNeTLB4A==
+"@frontegg/redux-store@6.172.0":
+  version "6.172.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.172.0.tgz#7a56835d3c4fd89d0f5db5bc946a2fa367524776"
+  integrity sha512-rER4zYd5fy8UaxY3zYX+nDcPh0OdIjirbAV+yR/3FU2BzSoMhYEFFYvZnwbUqgEF1nyZzRIMOYW/FaOfjs2OCw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1592,13 +1592,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.171.0":
-  version "6.171.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.171.0.tgz#52f0cfb2ba98d57c1725072a5484616e322c90c4"
-  integrity sha512-SNlsl0QU5weqk1iPoIYj2p6kuicbzytTpi6bhcZosKnwUEw8yPtzmMSGf1C3pQxRyEJHFE8qxspmWhL74PnoMg==
+"@frontegg/types@6.172.0":
+  version "6.172.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.172.0.tgz#023fdd78f5ba6a2359516b6a8f1bbce1a7cf6f7c"
+  integrity sha512-U1F7n0BpMYoUVG/G50gct/YIBY30OvisMARCdEBXOkvXCqyL39RCUsqNM0Xle8Dw9+KA/lxpko/lugdrc13EPQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.171.0"
+    "@frontegg/redux-store" "6.172.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,18 +1563,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.173.0":
-  version "6.173.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.173.0.tgz#85e2b8bf2c9f12e89c89bbd36e09896b6935437b"
-  integrity sha512-eMXZZQ2KFY5zplEFi+zga5uUNUaOzhsUK7ZEbG6NfbzPoHyHS+DOiLE/njaoxyiw/Acq4auCyNt2+h/NIG9dCQ==
+"@frontegg/js@6.174.0":
+  version "6.174.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.174.0.tgz#3411d1148eb79477791f5248c184bade82b84f0c"
+  integrity sha512-f91rcFO8lp/XDUkL65x0kzJGeoe0ao/7cOSW9vys8QM65WAm53ak0wFTPAter9GN1wuEofDjbaRrn8xOHijQwQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.173.0"
+    "@frontegg/types" "6.174.0"
 
-"@frontegg/redux-store@6.173.0":
-  version "6.173.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.173.0.tgz#97daae7627e64573acdff64bb30c2e150dea8106"
-  integrity sha512-YhjovUbpkxhEmtWDZokmcXvXv9LcCfgQXBwLQeX0BAnleAZE1hoeQa5runkpQYpoHWdn33piZMhs+ZhFhFBU7w==
+"@frontegg/redux-store@6.174.0":
+  version "6.174.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.174.0.tgz#0af08844a93c5c8a4a87292536ab9fbc55d23299"
+  integrity sha512-b1KOgTJgPTT1zo5IJmNizx5Py42KiHeiKOxbFij2p5pWv6cD5Ubq1mk7IZpDcz2J7QrvhOr5ID9g9wPy6Fpv9w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1592,13 +1592,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.173.0":
-  version "6.173.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.173.0.tgz#8daab0a6cc1984ee8e596445c9c83c2d9547386c"
-  integrity sha512-ijCHSejGAAkeKWfja7ZX3qgT7OgEFXqu/gbex3sKZfx0K1K18oKI/CFsxskhJATRi/qqQj/5HZiE7Sk13u1ldQ==
+"@frontegg/types@6.174.0":
+  version "6.174.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.174.0.tgz#bfcc02ad62d4b117e0932bac4ffe41d88ecaf387"
+  integrity sha512-l6lEuC7AcgKge8ABgR6CQO4HNoFxjYXJ0lDLNgjv/mdOvBE/qXxdGNIU61ZHglPfeCYpzRucPXaH5+AIuOwl6g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.173.0"
+    "@frontegg/redux-store" "6.174.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,47 +1558,47 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@frontegg/entitlements-javascript-commons@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
-  integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
+"@frontegg/entitlements-javascript-commons@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
+  integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@6.174.0":
-  version "6.174.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.174.0.tgz#3411d1148eb79477791f5248c184bade82b84f0c"
-  integrity sha512-f91rcFO8lp/XDUkL65x0kzJGeoe0ao/7cOSW9vys8QM65WAm53ak0wFTPAter9GN1wuEofDjbaRrn8xOHijQwQ==
+"@frontegg/js@6.175.0":
+  version "6.175.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.175.0.tgz#543bb9bd0db6a97defc7433389cd886a7fa06843"
+  integrity sha512-EY3FwDjR3kcrgJBbMFP0B/xk0W496h+48lYFkAdgz+eiCXvVosmwTCxaRmtttYCBzqkoYNlgf3TkYtKSwBlF/w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.174.0"
+    "@frontegg/types" "6.175.0"
 
-"@frontegg/redux-store@6.174.0":
-  version "6.174.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.174.0.tgz#0af08844a93c5c8a4a87292536ab9fbc55d23299"
-  integrity sha512-b1KOgTJgPTT1zo5IJmNizx5Py42KiHeiKOxbFij2p5pWv6cD5Ubq1mk7IZpDcz2J7QrvhOr5ID9g9wPy6Fpv9w==
+"@frontegg/redux-store@6.175.0":
+  version "6.175.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.175.0.tgz#768565bc9c5e0540de7bc94dfbffd50770df115e"
+  integrity sha512-UJjP7F175QgqR47aM8UHZNnrwa5gi4znX0hMLyF4SUpUzcO7kbMWk5m8ze2BWryB7IL20X46pJZUZK22qih5yw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/entitlements-javascript-commons" "1.0.1"
-    "@frontegg/rest-api" "3.1.57"
+    "@frontegg/entitlements-javascript-commons" "1.1.2"
+    "@frontegg/rest-api" "3.1.59"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.1.57":
-  version "3.1.57"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.57.tgz#fa1890e7d1175ca6a31bec03bb8dd119dffe5a6f"
-  integrity sha512-n2sm4/Bh7lG2eJ6RgP4n9BUcOc9Mc4bnwr8ItmZwbNReWYieDcOX+R0ViuTOyDN5KLu0oV5I2Ii7mYnqtf8Q4A==
+"@frontegg/rest-api@3.1.59":
+  version "3.1.59"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.59.tgz#64f0231c9ff83c8052cef715bbc65ab891fc0a97"
+  integrity sha512-7bHNxduzuosoHckTzIG3Q3W4qo3bXK2Hxgs7V+uetUjRSLlxWAcYuPOt8XrNrPskG6ejPd0F0IcbOC3VwHNrxA==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/entitlements-javascript-commons" "1.0.1"
+    "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@6.174.0":
-  version "6.174.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.174.0.tgz#bfcc02ad62d4b117e0932bac4ffe41d88ecaf387"
-  integrity sha512-l6lEuC7AcgKge8ABgR6CQO4HNoFxjYXJ0lDLNgjv/mdOvBE/qXxdGNIU61ZHglPfeCYpzRucPXaH5+AIuOwl6g==
+"@frontegg/types@6.175.0":
+  version "6.175.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.175.0.tgz#16b8c1a6ddc5b79fa53cf88a409b699fe55860fc"
+  integrity sha512-1S8BvSDgIZ7t7Vlzu1U7b3waZvg1tLWkSCFjObRji5yALtk9Sph/4B+p8v+bTUp868dB6io9Ln3k9vRUxCMVgA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.174.0"
+    "@frontegg/redux-store" "6.175.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,18 +1563,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.170.0":
-  version "6.170.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.170.0.tgz#aee4ad737b31427e35282ecc171e3d5b75e430aa"
-  integrity sha512-GW6vVr337G6xiOGiL080EzwB/Py3C6jIglrY+Fb66b713ZOrQoAHX9g5culiukGS6DWPZ8MNEC6vpCRcxfXmmQ==
+"@frontegg/js@6.171.0":
+  version "6.171.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.171.0.tgz#5d68a925951b668565d0a09077f3e42ae3423877"
+  integrity sha512-7VYhY4qw3Dgkq8GzlTU39offTON3pLonoNtr4h7AkiIh/Lwqr/h0fSgwt1T2sZZn39s1PO752APtcGuEVTcC+g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.170.0"
+    "@frontegg/types" "6.171.0"
 
-"@frontegg/redux-store@6.170.0":
-  version "6.170.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.170.0.tgz#a3ebb5231b1380112ea97f81e76a6e6043f7fbc8"
-  integrity sha512-xF3Ih+o7Yna4b1xx5kq0O86Zd5/wNKOJAKUKWeMht/UR7WsbT+kwncrCVC+/FGGI18aNxV3goSlld+oKhjF/yQ==
+"@frontegg/redux-store@6.171.0":
+  version "6.171.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.171.0.tgz#69b34a58ff3e1b5e25b9ee60e9ee7cf35677300c"
+  integrity sha512-lwkRb2L6WTNmjnUp9DzLe9KMMdKvKHW/9YIVjKdLRZke8PdF7zyBFWvolwnqqriXvIdRxa0pBAbXmRBNeTLB4A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1592,13 +1592,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.170.0":
-  version "6.170.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.170.0.tgz#d40181278e49ba10a63ed153908883dc84c54769"
-  integrity sha512-CMMg2uWBzDTSOtIVqaZ+i2njJ7iixWqQMt7qVDj9TATArJtmnSBUkIuRuiYhdhgj3HGNIOuTGb8Q6fjtjUHxhg==
+"@frontegg/types@6.171.0":
+  version "6.171.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.171.0.tgz#52f0cfb2ba98d57c1725072a5484616e322c90c4"
+  integrity sha512-SNlsl0QU5weqk1iPoIYj2p6kuicbzytTpi6bhcZosKnwUEw8yPtzmMSGf1C3pQxRyEJHFE8qxspmWhL74PnoMg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.170.0"
+    "@frontegg/redux-store" "6.171.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,18 +1563,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.169.0":
-  version "6.169.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.169.0.tgz#d14b738b7a501d9e8a366ae3485bcb0f36732f85"
-  integrity sha512-JZVlGcsQ0HQNV/ihJteC1QSiFUCa6Pw/RtR1q8twk6IcUA71Dvck1qpnmfBTuNHVfTzRfPZnc9QbzMUQGbS/5w==
+"@frontegg/js@6.170.0":
+  version "6.170.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.170.0.tgz#aee4ad737b31427e35282ecc171e3d5b75e430aa"
+  integrity sha512-GW6vVr337G6xiOGiL080EzwB/Py3C6jIglrY+Fb66b713ZOrQoAHX9g5culiukGS6DWPZ8MNEC6vpCRcxfXmmQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.169.0"
+    "@frontegg/types" "6.170.0"
 
-"@frontegg/redux-store@6.169.0":
-  version "6.169.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.169.0.tgz#6087b9d1542e558209dff40a5c2c047d96d28960"
-  integrity sha512-HdrBz0D2axRb4H8AVj4Pvg1wrJ9yXtG7Y60HXtKOFEF5SSiUGBtRR3rPefxiB+czW5PJPKALK/GgKNLOAdEfvg==
+"@frontegg/redux-store@6.170.0":
+  version "6.170.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.170.0.tgz#a3ebb5231b1380112ea97f81e76a6e6043f7fbc8"
+  integrity sha512-xF3Ih+o7Yna4b1xx5kq0O86Zd5/wNKOJAKUKWeMht/UR7WsbT+kwncrCVC+/FGGI18aNxV3goSlld+oKhjF/yQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1592,13 +1592,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.169.0":
-  version "6.169.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.169.0.tgz#fb28e07d1f8ed4c213168964938cea284f9e4f16"
-  integrity sha512-WMFmm9+uO3axMZqHQzx49sbdxJp+zH7HpKWVU0fpDm2phYh07GC/PV0P9SiYWfnwWPxI18xCSwDeZLdjgPaiaQ==
+"@frontegg/types@6.170.0":
+  version "6.170.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.170.0.tgz#d40181278e49ba10a63ed153908883dc84c54769"
+  integrity sha512-CMMg2uWBzDTSOtIVqaZ+i2njJ7iixWqQMt7qVDj9TATArJtmnSBUkIuRuiYhdhgj3HGNIOuTGb8Q6fjtjUHxhg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.169.0"
+    "@frontegg/redux-store" "6.170.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,18 +1563,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.168.0":
-  version "6.168.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.168.0.tgz#b41d04a40424554e2b012c7f6f456865a579ce69"
-  integrity sha512-J+xqGzPn4yn3vFcsWIowUsoz4qSBc/5DMASRrkDgoehKUhaIAVuc+vMcZbtrKnfaMRKlCpMnaJ7SUDwcAAEVxQ==
+"@frontegg/js@6.169.0":
+  version "6.169.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.169.0.tgz#d14b738b7a501d9e8a366ae3485bcb0f36732f85"
+  integrity sha512-JZVlGcsQ0HQNV/ihJteC1QSiFUCa6Pw/RtR1q8twk6IcUA71Dvck1qpnmfBTuNHVfTzRfPZnc9QbzMUQGbS/5w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.168.0"
+    "@frontegg/types" "6.169.0"
 
-"@frontegg/redux-store@6.168.0":
-  version "6.168.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.168.0.tgz#46e2f0ea80908eb1e0ac149f4a1b3d5b87bc1c20"
-  integrity sha512-ZmacBo9r6UvqshmRJ5rPEoiPySNIkT9VSIret6tgPdixVNZsxeOy5uAkYMlevmTedS42YLWFqcgXoSIJZoRm+A==
+"@frontegg/redux-store@6.169.0":
+  version "6.169.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.169.0.tgz#6087b9d1542e558209dff40a5c2c047d96d28960"
+  integrity sha512-HdrBz0D2axRb4H8AVj4Pvg1wrJ9yXtG7Y60HXtKOFEF5SSiUGBtRR3rPefxiB+czW5PJPKALK/GgKNLOAdEfvg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1592,13 +1592,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.168.0":
-  version "6.168.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.168.0.tgz#d674d5edbe6911b811c9e54f4de9ac359ff6bd24"
-  integrity sha512-cC6wxOFxKYQTN31u+6tXwDpEgd677mWvRG8UXwXxN4+nm9hzPz9YIB13IJ5o9AIt9ZQ+4wkE4K0T4hHl6dTq/w==
+"@frontegg/types@6.169.0":
+  version "6.169.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.169.0.tgz#fb28e07d1f8ed4c213168964938cea284f9e4f16"
+  integrity sha512-WMFmm9+uO3axMZqHQzx49sbdxJp+zH7HpKWVU0fpDm2phYh07GC/PV0P9SiYWfnwWPxI18xCSwDeZLdjgPaiaQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.168.0"
+    "@frontegg/redux-store" "6.169.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-14910 - Fixed handling entitlements errors 
- FR-14740 - Send tenant alias for hosted custom login auth user
- FR-14197 - Added Canada to MFA SMS list of countries
- FR-14859 - Fixed roles filtering for MSP
- FR-14855 - Added support for social login consent, by default it is false.
- FR-14813 - Added support for open app page with basename
- FR-14813 - Added support for mobile deep link redirect page
