### PR TITLE
Update Frontegg AdminPortal to 7.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.56.0",
+    "@frontegg/js": "7.57.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.55.0",
+    "@frontegg/js": "7.56.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.55.0",
+    "@frontegg/js": "7.56.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.56.0",
+    "@frontegg/js": "7.57.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.56.0":
-  version "7.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.56.0.tgz#b75c4aa8f7211aac2a8b19b0e11ceed6719bd7f4"
-  integrity sha512-88DemISbKM4CYd2w75pSykh+S4tAMONXxPSWX3Q+eHy9DBeffPKbyqBYY1278CH+klkFOEUhgd2LX6j93I9+0Q==
+"@frontegg/js@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.57.0.tgz#4bcdea8049500d085a48c36b8e610441c047d137"
+  integrity sha512-kWQ4cF6wmlpQjk9qoCK4pjPjQH+rq30vMzmUnJnvVJJNeYaD4L/+NFDEkMlfXkM7qMnmFejA/l9E2N941Odzpg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.56.0"
+    "@frontegg/types" "7.57.0"
 
-"@frontegg/redux-store@7.56.0":
-  version "7.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.56.0.tgz#511ffe13084294c02df32b26a861d6a6cdb5c272"
-  integrity sha512-fDRwR4ili6v+HWBzmaI4ccBbid8T+QCY5OvC1szMty9JrgfFkahyhy8RiG/l3WBVP2D4rOOHyPEAZ0SEW0pOEQ==
+"@frontegg/redux-store@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.57.0.tgz#7b8427603da7211c038b0c1b71714e96d9c989e0"
+  integrity sha512-XFB6AITK0N4M1RLx+BiUTPG62CGGZCLertSPaq4JBNjQ/b3aEJIRLvPX6Y2GQNikVQ8F+8Ih09qwbJUvyfrylg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.56.0"
+    "@frontegg/rest-api" "7.57.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.56.0":
-  version "7.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.56.0.tgz#8dcee55a1a4333df2a8b4a8ee84b645292415536"
-  integrity sha512-nxaKKSaGK4asl9dZvDaygQosaRIxlV4lKnRyKKd/xlsQ0C4HP/WT/759eCPzBw+OWoMjjpwX8NuteKRuCSpXiQ==
+"@frontegg/rest-api@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.57.0.tgz#10a202321bb60d59f106a6573089814354c8a086"
+  integrity sha512-aZ0TGI9Ofr1ws8DVqdmxGWHM9KR3UqOovZtrOa0WMefEdx06Oh6p+O4eZWvLYeTJbI5CM72PP80yyEZqEx4x0w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.56.0":
-  version "7.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.56.0.tgz#c17b154599bb3e6d93b14ded35b7d0ba5f877dcc"
-  integrity sha512-sJk0XdRNwz3N7/3gPK+J/mItIFBNIbDyrUxGNfXvro/TM/OJf/KhzFPBUo8CjKoBg3HX0XDuYvDh+ueRMglxuA==
+"@frontegg/types@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.57.0.tgz#422760f3de45eabcaa19ae9da7d7b3fa7e9d1641"
+  integrity sha512-g5mdPCz0r1QNWPI7+aQ9KBK1DvixSvrs0gZ4mqUqJhQ35q6AQOBF4bkpDwAu46dOTVUvtMGr6jIcVw85Co2bUg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.56.0"
+    "@frontegg/redux-store" "7.57.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.55.0":
-  version "7.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.55.0.tgz#383885a3c8d2ed6fc800751465b5e5c7727fa555"
-  integrity sha512-wShU5OBoXxxNhMvE8K8uK7wTt5kCvsZsboUG/7DzTr6LFN/O5CTLtuEKYs5CswEzVnUOyYq60qr7VLGaFl+WgQ==
+"@frontegg/js@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.56.0.tgz#b75c4aa8f7211aac2a8b19b0e11ceed6719bd7f4"
+  integrity sha512-88DemISbKM4CYd2w75pSykh+S4tAMONXxPSWX3Q+eHy9DBeffPKbyqBYY1278CH+klkFOEUhgd2LX6j93I9+0Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.55.0"
+    "@frontegg/types" "7.56.0"
 
-"@frontegg/redux-store@7.55.0":
-  version "7.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.55.0.tgz#641a9c9ea5e17c56ccbe374ccd7f20295e5b64cf"
-  integrity sha512-IPwDLiG/nbRg7enApqZD+SbGnNpy0yfExIdeFL3ZxeNZryfmb03Q5vglseODCG2qS3d1qpurtXizf+F6m5qqlQ==
+"@frontegg/redux-store@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.56.0.tgz#511ffe13084294c02df32b26a861d6a6cdb5c272"
+  integrity sha512-fDRwR4ili6v+HWBzmaI4ccBbid8T+QCY5OvC1szMty9JrgfFkahyhy8RiG/l3WBVP2D4rOOHyPEAZ0SEW0pOEQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.55.0"
+    "@frontegg/rest-api" "7.56.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.55.0":
-  version "7.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.55.0.tgz#fd13dc905f7ec7c5e1d8f7b3f8f308874c7b4c68"
-  integrity sha512-lmjQXwmKu8KiBzfYn4mDTkWCc1jiVFB3N3NbKiEoOQ/2VyG5nAAlN5jWrzQQou+7FvUr+WSiZ0ZATWNGhhFanw==
+"@frontegg/rest-api@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.56.0.tgz#8dcee55a1a4333df2a8b4a8ee84b645292415536"
+  integrity sha512-nxaKKSaGK4asl9dZvDaygQosaRIxlV4lKnRyKKd/xlsQ0C4HP/WT/759eCPzBw+OWoMjjpwX8NuteKRuCSpXiQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.55.0":
-  version "7.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.55.0.tgz#27969a47b73b13a3035eb2ca4258978c515e4af5"
-  integrity sha512-2cINqj4KFTi/lZ+UgQxfNvKP6W9+uqQ2z6FJQoD5pTHha2ddKz7lG/3gBcbnyRw3dyyDt3cpKVa21T4cdbYzWQ==
+"@frontegg/types@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.56.0.tgz#c17b154599bb3e6d93b14ded35b7d0ba5f877dcc"
+  integrity sha512-sJk0XdRNwz3N7/3gPK+J/mItIFBNIbDyrUxGNfXvro/TM/OJf/KhzFPBUo8CjKoBg3HX0XDuYvDh+ueRMglxuA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.55.0"
+    "@frontegg/redux-store" "7.56.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-18630 - Fixed input transparent autofill for vite
- FR-15942 - Changed titles in SSO configuration guides
- FR-19747 - Added a pre step toggler to the dashboard that enables a confirmation mechanism on relevant emails, to prevent automated scanners from invalidating magic links


- FR-19677 - Added hebrew translations for the pre step screens
- FR-19547 - Changed pre step titles
