### PR TITLE
Update Frontegg AdminPortal to 7.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.80.0",
+    "@frontegg/js": "7.81.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.80.0",
+    "@frontegg/js": "7.81.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.80.0":
-  version "7.80.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.80.0.tgz#8c96440b57d4485759e9a222d2a5b302c647f515"
-  integrity sha512-p54pU7YAyYNjrPGnl2BT1SeDHIWqXFVjbl52N0geAVuqS9sze/Lta1KDCrNhzVeET+jCa2IiiUry/koGNmZYwg==
+"@frontegg/js@7.81.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.81.0.tgz#d4a9e6399b3d34eb6638220606ca94a72a55ebe8"
+  integrity sha512-6YkunGjxLjF41cDah+5hsH8cXIO5ut8HzZy4BCHKV+AI5WrBEKMCKymei89f/RCi/Q4wtjuSMWngEI+kfAO8lg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.80.0"
+    "@frontegg/types" "7.81.0"
 
-"@frontegg/redux-store@7.80.0":
-  version "7.80.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.80.0.tgz#fe8293e40c536f8d73e73aa00a731be839c21cfc"
-  integrity sha512-BMNgAeL0+19SvnvXBRkZ8+1pyPWeu9zufex1xyfdfA3hyPxl7OzNxzAKcbF5LFc0mIVPylJ3pUXXTaJpVmbUCQ==
+"@frontegg/redux-store@7.81.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.81.0.tgz#e14f5f673936d2c36eab6c28bdeb11ad5821d9f0"
+  integrity sha512-hIsEJZKPHSQBX2oL2pGABNO54IrHsRkqOz27BKWRAMIEuwGDMynl3RqBCSi+hPgAibZnV1yhXFVQIBQpu1dSQg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.80.0"
+    "@frontegg/rest-api" "7.81.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.80.0":
-  version "7.80.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.80.0.tgz#6ac3226a91f8892e8a79c6b61b21a913d3cb9bac"
-  integrity sha512-z2clNee6S/729XHnLCwDGDMnH2mB3y/CoSYI8k4MrgIM5TNJh79SkuIF4Xg0dRSdmCEKWi+UzYOIUD1BBEKYDw==
+"@frontegg/rest-api@7.81.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.81.0.tgz#2ad07936aa5fff8539be50ddfee8b30c7871bc1f"
+  integrity sha512-Qn7SMtCFmh0hfQ6J361tH+2v5VzSjydgLk4HwK6Ddbse+k9iGOiu/Jt3PZzI+TXeb+o0GJaNp81AvSX0YkU0SQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.80.0":
-  version "7.80.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.80.0.tgz#75532e571b68a89f32dd1e33528811ad4fcce2dd"
-  integrity sha512-dwQtfnpdUKIjkyQ3VIdb4Xz1bqi6XagGEpbEPkVigZEwaa2Al95RTVxV1nUYzv9X4Jeu4s77YjHwG1lwSaEnFw==
+"@frontegg/types@7.81.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.81.0.tgz#c92e9ea3fda1855fc90c767cab4e1deb4a71d53c"
+  integrity sha512-AAzUHI6FqjDDTes2gbZHxwlPSRFJ7/IOb2Y2ewgMtf31m0m6MqzOIF2+8Np3dI16XhON2jzXSuSRV5pZOKvatA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.80.0"
+    "@frontegg/redux-store" "7.81.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-21351 - Changed user loading methods to use the new V3 API
- FR-21350 - Added usage for tenant-application access types in hosted Admin box
