### PR TITLE
Update Frontegg AdminPortal to 7.84.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.83.0",
+    "@frontegg/js": "7.84.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.82.0",
+    "@frontegg/js": "7.83.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.83.0",
+    "@frontegg/js": "7.84.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.82.0",
+    "@frontegg/js": "7.83.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.83.0":
-  version "7.83.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.83.0.tgz#565f29ac6764f6e4ea8386e741629e9b00e755ca"
-  integrity sha512-ZUhQ0eix2/Si4HwV1hLENIgEPd53kAHyyX6RTOXVv2gphXC4Dk8/TDaSJGCEfRHUqhnrg+NeaPSQ5CEu6eYUmg==
+"@frontegg/js@7.84.0":
+  version "7.84.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.84.0.tgz#8f2096df50df0a813e2ec88753ddfe6d6fead182"
+  integrity sha512-BhcqNdhmA0VQBkWjuMmvL5nygcPhfz90/k8dydKV7udtLIw7gHf8id6yTJ/Hpgb1jaewCmagFpPjFFu6oTUJ0g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.83.0"
+    "@frontegg/types" "7.84.0"
 
-"@frontegg/redux-store@7.83.0":
-  version "7.83.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.83.0.tgz#ad10e370d4652c0428ac29c2df972051624da3ba"
-  integrity sha512-qILQWprfZDRMaJHWolqbUYVu1Mp75MJylzEHFiHWjOv8VJavN6afEQXklxSnNQy1WN77UKl3ZY90kBUmBSd5eA==
+"@frontegg/redux-store@7.84.0":
+  version "7.84.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.84.0.tgz#d3369d1c12471ffd417d2ce07d2ba066c8a7c630"
+  integrity sha512-ThBAscGdr3GcY9wmQSNOL2O/Bw2MSGkeGQhC2hA/KpzcIT3pIX5k5i7W/xoLmAB52sVp6lL9ckqMOEpDFNMKhg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.83.0"
+    "@frontegg/rest-api" "7.84.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.83.0":
-  version "7.83.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.83.0.tgz#e72fd2021ab638e6a9bf0f723eabaeedf99051fd"
-  integrity sha512-nabe+nQzMrgqiSHKOXn2GL92/1iysoE089RIDvFLqkIHOEF4JH2Er2GWETQRzKzLh8fcSgz5/NbkNNzbUffDAQ==
+"@frontegg/rest-api@7.84.0":
+  version "7.84.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.84.0.tgz#cef20d73060bec0d61b65c20ea6f130b149ce2ad"
+  integrity sha512-1AoMQRT9MUgZxWIe8V29R/TuJNQkUsS+4pSQo8KiRH2IsP+HYCKSF9Jp74ZWrXIMYLXXrLxNIj2pwwXHYYMiiQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.83.0":
-  version "7.83.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.83.0.tgz#abd6d12663cddeead350c5a5a0b32e2bca179b62"
-  integrity sha512-X5bGn/d66DevLRKmMLDcJWVxeuE/nDzVWki6nmbRMPFhXgi0/ODBxy+AEUiV20WtolQXgFbYhoW06O39i/4XOw==
+"@frontegg/types@7.84.0":
+  version "7.84.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.84.0.tgz#24015fc9e68997549f672eb2efb9843199f615fa"
+  integrity sha512-824mB/kmgl8R3C8UYaQw3bb9x10AZbZeR/AOzYBHNpd7LSfjyOik7VDBIMyZDLua9RUDpIoaOkxhE4xhiWEkzQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.83.0"
+    "@frontegg/redux-store" "7.84.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.82.0":
-  version "7.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.82.0.tgz#f3ff0124b3de720999c8f2d3c9b8ef5efec0c6d1"
-  integrity sha512-OF/P3xhyoCOU2d/M76PN5v8V2KNEQw+gNWcg4+JEhz7lFRLSOZaQ5GO415ld9aACSKt6dqW7WoB8ZdoHTzY85g==
+"@frontegg/js@7.83.0":
+  version "7.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.83.0.tgz#565f29ac6764f6e4ea8386e741629e9b00e755ca"
+  integrity sha512-ZUhQ0eix2/Si4HwV1hLENIgEPd53kAHyyX6RTOXVv2gphXC4Dk8/TDaSJGCEfRHUqhnrg+NeaPSQ5CEu6eYUmg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.82.0"
+    "@frontegg/types" "7.83.0"
 
-"@frontegg/redux-store@7.82.0":
-  version "7.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.82.0.tgz#2a42b3f7617cba4e150c4f092d18d4a1533f3916"
-  integrity sha512-8AKjQu8ZON9QzJbEQ7J6F1rFoitorHlEO2UWSxxe2XVbbvgjuiX7yxwLJvaYFJlrDb5fcp4as9EZeJpyrnLo+Q==
+"@frontegg/redux-store@7.83.0":
+  version "7.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.83.0.tgz#ad10e370d4652c0428ac29c2df972051624da3ba"
+  integrity sha512-qILQWprfZDRMaJHWolqbUYVu1Mp75MJylzEHFiHWjOv8VJavN6afEQXklxSnNQy1WN77UKl3ZY90kBUmBSd5eA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.82.0"
+    "@frontegg/rest-api" "7.83.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.82.0":
-  version "7.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.82.0.tgz#6411b64786cb4fec4ba8bd6154fde61ab359cd98"
-  integrity sha512-bSpbiS/TNyJr3q1If/hSnEtO4BqxsYiTYeFV/j9+b+iIVFavxo1CL97QO5FEUc+W7sCAeShXnuyYOpm+6Ls8fA==
+"@frontegg/rest-api@7.83.0":
+  version "7.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.83.0.tgz#e72fd2021ab638e6a9bf0f723eabaeedf99051fd"
+  integrity sha512-nabe+nQzMrgqiSHKOXn2GL92/1iysoE089RIDvFLqkIHOEF4JH2Er2GWETQRzKzLh8fcSgz5/NbkNNzbUffDAQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.82.0":
-  version "7.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.82.0.tgz#fdb1c42f22e91267e1faff8c72743b82362bab4c"
-  integrity sha512-j1xSupUTgBzzoOs98iouB3+LToZ0Wet0cTnruAJ+4FazPu4E1bXx/OQiMR2azLrGJZT2VUD0TPy25gBk9mLGOg==
+"@frontegg/types@7.83.0":
+  version "7.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.83.0.tgz#abd6d12663cddeead350c5a5a0b32e2bca179b62"
+  integrity sha512-X5bGn/d66DevLRKmMLDcJWVxeuE/nDzVWki6nmbRMPFhXgi0/ODBxy+AEUiV20WtolQXgFbYhoW06O39i/4XOw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.82.0"
+    "@frontegg/redux-store" "7.83.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-21916 - Added username field to InviteUserForm with validation
- FR-21330 - Fixed empty names
- FR-22047 - Fixed user invite initial dialog to use inviteByEmailEnable...
- FR-21924 - Added roles to invitation link flow
- FR-21914 - Added smart navigation for invite dialog based on enabled …
- FR-21913 - Added dialog step management enum and logic for enhanced invite user modal


- FR-22006 - Added signup to login direct action
- FR-21912 - Added InvitationLink component (basic version)
- FR-21911 - Added InviteUserViaLink component (basic version)
- FR-21910 - Added an InviteUserSelector component
- FR-21909 - Changed InviteUserForm component to separate file from InviteUserDialog
