### PR TITLE
fix - e2e trigger

### DIFF
--- a/.github/actions/trigger-e2e-test/action.yaml
+++ b/.github/actions/trigger-e2e-test/action.yaml
@@ -21,17 +21,19 @@ runs:
   steps:
     - id: create_bot_token
       name: Create bot token
-      uses: wow-actions/use-app-token@v2
+      uses: actions/create-github-app-token@v1
       with:
-        app_id: ${{ inputs.bot_app_id }}
-        private_key: ${{ inputs.bot_app_key }}
+        app-id: ${{ inputs.bot_app_id }}
+        private-key: ${{ inputs.bot_app_key }}
+        repositories: e2e-system-tests
+        owner: frontegg
     - name: "Trigger E2E tests"
-      uses: actions/github-script@v5
+      uses: actions/github-script@v7
       env:
         version: ${{ inputs.version }}
         sha: ${{ inputs.sha }}
       with:
-        github-token: ${{ steps.create_bot_token.outputs.BOT_TOKEN }}
+        github-token: ${{ steps.create_bot_token.outputs.token }}
         script: |
           const {sha, version} = process.env;
           const repo = 'frontegg-angular'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches CI automation for dispatching E2E workflows; misconfiguration of token permissions/outputs could prevent E2E runs from triggering.
> 
> **Overview**
> Updates the `trigger-e2e-test` composite action to generate a GitHub App token via `actions/create-github-app-token@v1` (scoped to the `frontegg/e2e-system-tests` repo) instead of `wow-actions/use-app-token@v2`.
> 
> Bumps `actions/github-script` from `v5` to `v7` and switches the dispatch step to use the new token output (`steps.create_bot_token.outputs.token`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ce2f4324474aa0600ab462e31e2617cbb34fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->