### PR TITLE
Update Frontegg AdminPortal to 7.107.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.106.0",
+    "@frontegg/js": "7.107.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.106.0",
+    "@frontegg/js": "7.107.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.106.0.tgz#83dcb57ce1463c8930b55ef03c9814b1996618e6"
-  integrity sha512-68TUOiG6xl5N9IXGmhDOeV0jKWwN9tQqPc98nI3OxHbZyPPOYxWINOTpj24W4wb81nU4pCZ8ffuGneL76QKbkQ==
+"@frontegg/js@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.107.0.tgz#d88260b61dfa5263841f873c168d04fc82a7f49f"
+  integrity sha512-0QoVHi7Msvo2qhxBfebYt22KUGr8g+fwypx0/A3cbfLpwj60nuO1CxDz4FJWMiUG3a6gcG0cnMH5GM0lmVlANQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.106.0"
+    "@frontegg/types" "7.107.0"
 
-"@frontegg/redux-store@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.106.0.tgz#4cf6e36ac939bd88b1e2147f19b523b83011b89a"
-  integrity sha512-H4QXJEPkQd2t505C92FanfjAW12kPIZsaal+tgReJQqEixQUL8wbXZoe9pp48s9qUgaKoUd1F+dQ0AkdFulO8A==
+"@frontegg/redux-store@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.107.0.tgz#1df08e7366ebe95c1ad66c1f894f4c28c54ca642"
+  integrity sha512-OqYQTsnYf8VrGdD3eXnYNwYdwvsGesdoLTVmATU3urOEMZn1hubEtgH102Tbr3u1h2/Q3GXUZmhgjQV8K8Z4wg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.106.0"
+    "@frontegg/rest-api" "7.107.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.106.0.tgz#779d18b9e5d59e4301197bf165219eb2c7d6290e"
-  integrity sha512-a28vI8oFIFJPeFqrLw+Q9aJxCyoWaB1eOGzV5j7F/M8Q+zko4ac3AMXCTf1MfWyrMKk71L5DLoSX8f5z6B0xhA==
+"@frontegg/rest-api@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.107.0.tgz#67fa90c6b2b7d8f272992177cb0f18a2987821c1"
+  integrity sha512-pRbfU7y8K2s1X16Eknlh/6mMiH31mLsMCZtEa8rVZrRQ/ZSVKaW9UZxNh+lttT90ZykTixN9KY2+3mxi6uOTFQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.106.0.tgz#1c59f8b36fb80b33eab84fa6ad076815d4a499ed"
-  integrity sha512-emVdoZKQZ4Am3VYeF93BYC+qkzcxbWWBdtk3LKxwzBfzk6Fo7aLHNV3ThWZf2igNU+z5aK0fMyoM4Kiijb6eYw==
+"@frontegg/types@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.107.0.tgz#ef9aca80c1c9b9edf563d9b909c5166263f4609a"
+  integrity sha512-GKGChl1HfcHMBoYli3/zDGf93e3M5HUno7pCV1vs5umOOBz8O4jtYsRlmtyCPduaLAUrvzxDS2pQrqfs8DwLHQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.106.0"
+    "@frontegg/redux-store" "7.107.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24663 - Fixed country restriction dark theme input
- FR-24664 - Fixed country field background in modern theme
- FR-24693 - Fixed country restriction admin portal not full list of countries display for allow deny lists
- FR-24661 - Fixed country restriction tip counter updates
- FR-24667 - Added country restriction admin portal current country is not added to the list after enabling the counter restriction toggle

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump: updates the Frontegg SDK and its transitive packages via lockfile changes, with no application code modifications.
> 
> **Overview**
> Updates the project and library dependency on `@frontegg/js` from `7.106.0` to `7.107.0` in both the root and `projects/frontegg-app` packages.
> 
> Refreshes `yarn.lock` to pull in the corresponding `7.107.0` versions of Frontegg transitive dependencies (`@frontegg/types`, `@frontegg/redux-store`, `@frontegg/rest-api`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68e754d95d36292b90afaa266cd70f064f75975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->