### PR TITLE
Update Frontegg AdminPortal to 7.111.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.110.0",
+    "@frontegg/js": "7.111.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.110.0",
+    "@frontegg/js": "7.111.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.110.0.tgz#1f54937abd539074d7e2c986bf840b9ec7c37dc0"
-  integrity sha512-pjxCQrrrQp+qaiWAbRg9BF/0z4xUk69WoIO14S9gEQjtctez90SjuW2Ah7ndYnX1jDiL69Usm1HeP8bT/fNEFQ==
+"@frontegg/js@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.111.0.tgz#ab06b82501a072751e0fd964c39d423fab8558c1"
+  integrity sha512-pDNJLykhVNwO9smFbWTjNKOtO2XOhLrTwYelC0Hah0cC/BNtZyogV8SoGOy5CP0ni1DFGBGJjjZNxRaZT8YwQw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.110.0"
+    "@frontegg/types" "7.111.0"
 
-"@frontegg/redux-store@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.110.0.tgz#b4a453fcf16eb44183b0242768b841eb5d4e0a19"
-  integrity sha512-eyX+G1yxls2XAubra1IB2rJvt17a2fk90fyv76/X8cK6WfamVItfvoVc0w6D0+QWKmQ0c0oCFCIDuyVIeK86Og==
+"@frontegg/redux-store@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.111.0.tgz#eb1acc6941ab94abd99802ba021a793185daa38b"
+  integrity sha512-OEdiong8II+CVfBDfObecO5G2Qb6rEOCnsKULHdFS4tOKrVTPo7EkQn1zE6xZMbaYolugzfpD8wbv1Kk7dnu9A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.110.0"
+    "@frontegg/rest-api" "7.111.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.110.0.tgz#44645a7af8c9547e3de54157819d712ac862a306"
-  integrity sha512-sip50EJ6bJfvcXW9j+kt8xNRCNeSEnCNworJ7QHZQzS80pO0RAWTwn9to0yHlLxcSWBvE6JytAPAwnsDn48bYg==
+"@frontegg/rest-api@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.111.0.tgz#fdc645698b5f6c9844d0eec44d82cba95d19a22e"
+  integrity sha512-iHoDj+bvfdeUl62HM3q92wrFjyemopVhgykxPu//KTfCJJf+eZAdFuoLV4DOKnT7VRKa0oj5pDMACnB3UuuDfA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.110.0.tgz#2314bb43b5d31be4c9ab7be52adaf20f6d68b31c"
-  integrity sha512-Jzybo6foUBZh4k3CsN2r/AKoaF2V0EANq/3EyvMqT+3vnVtlYX2RPsmERuxK4ddKXzppuYHKxCXjK88Hn8voJg==
+"@frontegg/types@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.111.0.tgz#fc1d0715db85e7bf42c0ccad34f738a51f509717"
+  integrity sha512-06iGx5uNKEtVwHwkaI0LU8WASbYI1wvhl7dLv49WXSDAYM/CQCpzkUr9sIPJFZt/d93pL3Max/KGjUkynwEMNQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.110.0"
+    "@frontegg/redux-store" "7.111.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24579 - Added native token bridge for the admin portal (no second login)
- FR-20973 - Fixed sso with username
- FR-20975 - Fixed description username login with magic code
- FR-22194 - Fixed error massage of username already exists missing from UI
- FR-20977 - Fixed resend with username in magic link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it pulls in upstream auth, SSO, and admin-portal login behavior where regressions would affect end-user sign-in flows.
> 
> **Overview**
> This PR **only updates the pinned `@frontegg/js` version** from `7.110.0` to `7.111.0` in the root `package.json` and `projects/frontegg-app/package.json`, and refreshes `yarn.lock` for `@frontegg/js` and its transitive packages (`@frontegg/types`, `@frontegg/redux-store`, `@frontegg/rest-api`). There are **no application or library source changes** in this repo—the Admin Portal / auth behavior called out in the PR description comes from the upgraded SDK release (e.g. admin portal native token bridge, username SSO and magic-link fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5db1d9ffcb4131b34ad71220cc8e286c8733b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->