### PR TITLE
Update Frontegg AdminPortal to 7.112.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.111.0",
+    "@frontegg/js": "7.112.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.111.0",
+    "@frontegg/js": "7.112.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.111.0.tgz#ab06b82501a072751e0fd964c39d423fab8558c1"
-  integrity sha512-pDNJLykhVNwO9smFbWTjNKOtO2XOhLrTwYelC0Hah0cC/BNtZyogV8SoGOy5CP0ni1DFGBGJjjZNxRaZT8YwQw==
+"@frontegg/js@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.112.0.tgz#183503ebbd89b334a37dcf65749d59941ef30120"
+  integrity sha512-RSKi5vg8fBePLl1bD7MrsKIt4QVHpUKl1p98Bf2lh9vZtCwK6ZNucnF/oeLio0HGUUY8ciCZJEJgX/RW7quwCw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.111.0"
+    "@frontegg/types" "7.112.0"
 
-"@frontegg/redux-store@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.111.0.tgz#eb1acc6941ab94abd99802ba021a793185daa38b"
-  integrity sha512-OEdiong8II+CVfBDfObecO5G2Qb6rEOCnsKULHdFS4tOKrVTPo7EkQn1zE6xZMbaYolugzfpD8wbv1Kk7dnu9A==
+"@frontegg/redux-store@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.112.0.tgz#623992069735a4fee82ba916a29a2731f8ba529f"
+  integrity sha512-FV9UDVHac6GCiBygdGRScsdEqftXMaLxKlJiBswGAhHBGlnCdC7G/8kK/6BmCYEUYbU4t5XbAc+rUyBarsPnDA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.111.0"
+    "@frontegg/rest-api" "7.112.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.111.0.tgz#fdc645698b5f6c9844d0eec44d82cba95d19a22e"
-  integrity sha512-iHoDj+bvfdeUl62HM3q92wrFjyemopVhgykxPu//KTfCJJf+eZAdFuoLV4DOKnT7VRKa0oj5pDMACnB3UuuDfA==
+"@frontegg/rest-api@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.112.0.tgz#dbb305895a0e9d6c23208667413c2888b48fcd93"
+  integrity sha512-0xC/oRUde3bbMl0zmTKn/3+hZHAtWm48aglybN2FiUd0I7XeIvzZYsQLCKs5xPWz79kxc5VhIWY8JB9sEMLFvw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.111.0.tgz#fc1d0715db85e7bf42c0ccad34f738a51f509717"
-  integrity sha512-06iGx5uNKEtVwHwkaI0LU8WASbYI1wvhl7dLv49WXSDAYM/CQCpzkUr9sIPJFZt/d93pL3Max/KGjUkynwEMNQ==
+"@frontegg/types@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.112.0.tgz#8e20e68077eec17a39fd23e46c8b162af33de1ed"
+  integrity sha512-Uhl+Pu0iUutHFG5hCWxeN6vqoll8abxNsFFWh14BExZ0aI50AMAbc6VsxpMDDKRXevxvqlSiVfUuVAgtn1XGyw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.111.0"
+    "@frontegg/redux-store" "7.112.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24579 - Fixed admin-portal redirect race on native auth handoff
- FR-24579 - Fixed admin-portal mobile bridge capability gating and stuck loading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application source changes—only pinned Frontegg SDK versions and lockfile updates.
> 
> **Overview**
> Bumps **`@frontegg/js`** from **7.111.0** to **7.112.0** in the root app and **`@frontegg/angular`** library, with **`yarn.lock`** updated for the aligned **`@frontegg/types`**, **`@frontegg/redux-store`**, and **`@frontegg/rest-api`** packages.
> 
> This pulls in Admin Portal fixes for **FR-24579**: a redirect race during native auth handoff, and mobile bridge capability gating that could leave the portal stuck loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282b4c84a844803151cfdeb85085920f524776b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->