### PR TITLE
Update Frontegg AdminPortal to 7.113.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.112.0",
+    "@frontegg/js": "7.113.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.112.0",
+    "@frontegg/js": "7.113.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.112.0.tgz#183503ebbd89b334a37dcf65749d59941ef30120"
-  integrity sha512-RSKi5vg8fBePLl1bD7MrsKIt4QVHpUKl1p98Bf2lh9vZtCwK6ZNucnF/oeLio0HGUUY8ciCZJEJgX/RW7quwCw==
+"@frontegg/js@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.113.0.tgz#204a18d336b69e9f1efc31c08511d51a0cc2b064"
+  integrity sha512-u+JW4WDDk6Kv8b3B+rjDy/XMawYQ7dIjCn/Xr+BeM1oiNoFQnLjC+iBNG+BpJPAO60Sahb/ilrUkd1bO36jSDw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.112.0"
+    "@frontegg/types" "7.113.0"
 
-"@frontegg/redux-store@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.112.0.tgz#623992069735a4fee82ba916a29a2731f8ba529f"
-  integrity sha512-FV9UDVHac6GCiBygdGRScsdEqftXMaLxKlJiBswGAhHBGlnCdC7G/8kK/6BmCYEUYbU4t5XbAc+rUyBarsPnDA==
+"@frontegg/redux-store@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.113.0.tgz#5f8587eaa35cf8f075e8f3bd60e107dae2bb0edb"
+  integrity sha512-NjmzBwK9T7OtI6rF1ZOlwuFwttHUb5QxCZaPq23McEtV7wNiIbMvWQpstnK0/WEV2odjWjYLrJO0n9PK4bpDcg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.112.0"
+    "@frontegg/rest-api" "7.113.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.112.0.tgz#dbb305895a0e9d6c23208667413c2888b48fcd93"
-  integrity sha512-0xC/oRUde3bbMl0zmTKn/3+hZHAtWm48aglybN2FiUd0I7XeIvzZYsQLCKs5xPWz79kxc5VhIWY8JB9sEMLFvw==
+"@frontegg/rest-api@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.113.0.tgz#f363cff59444cf2ad3022a0e2c051677e9037f43"
+  integrity sha512-3F1aerS8NUhiSyMoadcAz5NGY3W1dZNLuWFUYrlpHlUcMsrHHHAq8vuMsTZoKzxOGXuWH02zmEGqoLBijfOWIQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.112.0.tgz#8e20e68077eec17a39fd23e46c8b162af33de1ed"
-  integrity sha512-Uhl+Pu0iUutHFG5hCWxeN6vqoll8abxNsFFWh14BExZ0aI50AMAbc6VsxpMDDKRXevxvqlSiVfUuVAgtn1XGyw==
+"@frontegg/types@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.113.0.tgz#f5185721d7b301eef8d9a894b31b79344e497851"
+  integrity sha512-Mqp/nS4rM1WP5tg7cV355ajsMB7NMHe9kgrJHUZUf/MIye6IGhjLWx0zV/POfnS4/bJ82P4mxHIxlVEgnTiaKw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.112.0"
+    "@frontegg/redux-store" "7.113.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24579 - Fixed admin-portal white screen in mobile SDK by refreshing session from native tokens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is version pins and lockfile only; session/auth behavior changes live in the upstream @frontegg/js release, so regression risk is limited to consuming that fix.
> 
> **Overview**
> Bumps **`@frontegg/js`** from **7.112.0** to **7.113.0** in the root app, **`@frontegg/angular`** library package, and **`yarn.lock`** (including aligned **`@frontegg/types`**, **`@frontegg/redux-store`**, and **`@frontegg/rest-api`**).
> 
> This pulls in **FR-24579**: a fix for the **admin portal white screen** on the **mobile SDK** by **refreshing the session from native tokens**. No Angular wrapper code changes in this PR—only the Frontegg JS stack version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96f104d97f60aedc0b9b7311383326a3a5c8669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->