### PR TITLE
Update Frontegg AdminPortal to 7.117.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.115.0",
+    "@frontegg/js": "7.116.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^12.0.0",
     "@angular/platform-browser-dynamic": "^12.0.0",
     "@angular/router": "^12.0.0",
-    "@frontegg/js": "7.116.0",
+    "@frontegg/js": "7.117.0",
     "csstype": "^3.0.8",
     "rxjs": "~6.6.0",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.115.0",
+    "@frontegg/js": "7.116.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/projects/frontegg-app/package.json
+++ b/projects/frontegg-app/package.json
@@ -7,7 +7,7 @@
     "@angular/core": ">=12.0.0"
   },
   "dependencies": {
-    "@frontegg/js": "7.116.0",
+    "@frontegg/js": "7.117.0",
     "csstype": "^3.0.8",
     "fast-deep-equal": "^3.1.3",
     "stream": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.115.0.tgz#47e143fb18e3342fb21c83999108970c5560bc5c"
-  integrity sha512-07dxt0Lq3c3B1MHh4R1MJmJ9E0PhPdaXIcQUvXGOvxTWupOTo/Yn4FJEvlZKqf1YjZcLiKM2hOCCzd7GFjINXg==
+"@frontegg/js@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.116.0.tgz#0b15380ead744f99a3dd84721c649d0f7f59e4d8"
+  integrity sha512-XSJvtvxI9gBmBJ+F0ZJdF/UqiSJXOuaSy4IAy2vFfM9rsAeeKYOQY0XXwris2RvMs4sr5N2ZrjoexUsm7H5AEw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.115.0"
+    "@frontegg/types" "7.116.0"
 
-"@frontegg/redux-store@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.115.0.tgz#2f016ad28e196ee1725fe6f7983817231ae3f69f"
-  integrity sha512-1yaCLaQI4bG8b2doy++wA0IEuFHWokfeO6Xg/NHTj0sRIMbyQDusiUeYLsNHw99pwHdAQJGEjy+71zcS3UX/vQ==
+"@frontegg/redux-store@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.116.0.tgz#73aa8e3554411775d1b0a7a0e64a13cedeac5491"
+  integrity sha512-a1cy8OxWQY6RgFUNQspfYVN7xCZYAYx+MbOXM7jiz+jnbyGARmP8s3YPypb+CE1B6PVttWLXiLkn2ClATVUKxA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.115.0"
+    "@frontegg/rest-api" "7.116.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.115.0.tgz#9c2e0e3ee695e61211281bb5db6950baa0b5e3b4"
-  integrity sha512-EsXmjQjox6/zxNXZ375xM/P6V4R1fpyfTJ79ikwCc6N8CpR0OuBODSSlgKooZHnch1fnFnBNx+hoS5XWDpwrIA==
+"@frontegg/rest-api@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.116.0.tgz#945c6361de4301a624912ed06c0c78307ea4bf3e"
+  integrity sha512-rsFTq0i/PmVVCQ2EU3rCVrBBkY9LVDSUQ20G4Fp4SZrBobUTQvntyHbMFlUfK4Yeb6dTY4iZFM8IOzmqJv+21g==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.115.0.tgz#1b63d62159dc1b613d2553c6e722b3bb8060c1cf"
-  integrity sha512-nGNQjlQ2TtvqEwc1XUI3FUz8cCRmNH2OT2BjFTdUxWrL27zyD41L74bujdgMvqGTLrgXVraFoAFykmnJIf6/kw==
+"@frontegg/types@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.116.0.tgz#47e2e3dd36d9436b0614cbea9baa4acde12ac770"
+  integrity sha512-GzDEqgq0s/D/i3HP4WyIujf41QixPrveBjv3QRb8sjCjAN6GFetKjporEl0Dukydi5fmxw1ExScHn6SrQJgnBA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.115.0"
+    "@frontegg/redux-store" "7.116.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,43 +1549,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.116.0.tgz#0b15380ead744f99a3dd84721c649d0f7f59e4d8"
-  integrity sha512-XSJvtvxI9gBmBJ+F0ZJdF/UqiSJXOuaSy4IAy2vFfM9rsAeeKYOQY0XXwris2RvMs4sr5N2ZrjoexUsm7H5AEw==
+"@frontegg/js@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.117.0.tgz#042e0b9e61588211450fc9c8928693b54b53d487"
+  integrity sha512-nnB9Y7B8D2uDKX0z+YpN7JyhBpjwXitVECzs2XaUaNPWykL5D17vReK1TBZBl9D1IBuY6tfgXRQ+Hz7V5/cXhQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.116.0"
+    "@frontegg/types" "7.117.0"
 
-"@frontegg/redux-store@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.116.0.tgz#73aa8e3554411775d1b0a7a0e64a13cedeac5491"
-  integrity sha512-a1cy8OxWQY6RgFUNQspfYVN7xCZYAYx+MbOXM7jiz+jnbyGARmP8s3YPypb+CE1B6PVttWLXiLkn2ClATVUKxA==
+"@frontegg/redux-store@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.117.0.tgz#0e7e98b21b36623fc7b2d4009146cb8d01151e44"
+  integrity sha512-uJImfp5Yx/QF8ml79Uv9QjAtufXDKx0iS/y5a694dY6ycrTiSB4pfNvPb3htVLk2sIIpssk9Jt06PuflfgzAcA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.116.0"
+    "@frontegg/rest-api" "7.117.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.116.0.tgz#945c6361de4301a624912ed06c0c78307ea4bf3e"
-  integrity sha512-rsFTq0i/PmVVCQ2EU3rCVrBBkY9LVDSUQ20G4Fp4SZrBobUTQvntyHbMFlUfK4Yeb6dTY4iZFM8IOzmqJv+21g==
+"@frontegg/rest-api@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.117.0.tgz#dbbede10c18dd65dd74e7e2302cf1b687b5e2a13"
+  integrity sha512-kPs83HLvb8Z4/gf9wGeEH34AOIb2l9Ayv+WhK3QpwSvNBd02hTHhAYyW4ACAi/87Nd3cFSXnlejB/8lA3oEtfg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.116.0.tgz#47e2e3dd36d9436b0614cbea9baa4acde12ac770"
-  integrity sha512-GzDEqgq0s/D/i3HP4WyIujf41QixPrveBjv3QRb8sjCjAN6GFetKjporEl0Dukydi5fmxw1ExScHn6SrQJgnBA==
+"@frontegg/types@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.117.0.tgz#4e2b467cb4652add472c38406dcd54908bd27028"
+  integrity sha512-89UhOnzXld3pxPmkdePIko0fleSYQbvK28xh0Ym5cZAG/MsqAIGPgpHVA/T0+U2LwoEu+WJVmjrB1wASSzJg+g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.116.0"
+    "@frontegg/redux-store" "7.117.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-23757 - Fixed the actor of system audit logs to not be unknown

- FR-25580 - Fixed token refresh resilience with retry backoff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no local code changes; main risk is regressions or API changes inside the upstream `@frontegg/js` 7.117.0 package.
> 
> **Overview**
> Bumps the pinned **`@frontegg/js`** dependency from **7.115.0** to **7.117.0** in the root app and in **`@frontegg/angular`** (`projects/frontegg-app/package.json`), with **`yarn.lock`** updated for the matching **`@frontegg/types`**, **`@frontegg/redux-store`**, and **`@frontegg/rest-api`** versions.
> 
> There are **no Angular library or application code changes** in this PR; behavior updates (e.g. token refresh retry/backoff from upstream) come from the new Frontegg JS SDK release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd53840dd3a43053ceecd7289cefe6799d319b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->